### PR TITLE
Fix tools page layout and add image enhancer dropdown

### DIFF
--- a/app/ui/settings/tools_page.py
+++ b/app/ui/settings/tools_page.py
@@ -1,61 +1,91 @@
 from PySide6 import QtWidgets
-from ..dayu_widgets.label import MLabel
+
 from ..dayu_widgets.check_box import MCheckBox
+from ..dayu_widgets.label import MLabel
 from ..dayu_widgets.spin_box import MSpinBox
 from .utils import create_title_and_combo, set_combo_box_width
 
+
 class ToolsPage(QtWidgets.QWidget):
     def __init__(
-        self, 
-        translators: list[str], 
-        ocr_engines: list[str], 
+        self,
+        translators: list[str],
+        ocr_engines: list[str],
         detectors: list[str],
-        inpainters: list[str], 
-        inpaint_strategy: list[str], 
-                image_enhancers: list[str] | None = None,
-        parent=None
-    ):
+        inpainters: list[str],
+        inpaint_strategy: list[str],
+        image_enhancers: list[str] | None = None,
+        parent=None,
+    ) -> None:
         super().__init__(parent)
+
         self.translators = translators
         self.ocr_engines = ocr_engines
         self.detectors = detectors
         self.inpainters = inpainters
         self.inpaint_strategy = inpaint_strategy
-    self.image_enhancers = image_enhancers if image_enhancers is not None else ["None", "Basic", "Waifu2x"]            
-        
+        self.image_enhancers = image_enhancers or ["None", "Basic", "Waifu2x"]
 
         layout = QtWidgets.QVBoxLayout(self)
 
-        translator_widget, self.translator_combo = create_title_and_combo(self.tr("Translator"), self.translators, h4=True)
+        translator_widget, self.translator_combo = create_title_and_combo(
+            self.tr("Translator"),
+            self.translators,
+            h4=True,
+        )
         set_combo_box_width(self.translator_combo, self.translators)
-        enhancer_widget, self.image_enhancer_combo = create_title_and_combo(self.tr("Image Enhancer"), self.image_enhancers, h4=True)
+
+        enhancer_widget, self.image_enhancer_combo = create_title_and_combo(
+            self.tr("Image Enhancer"),
+            self.image_enhancers,
+            h4=True,
+        )
         set_combo_box_width(self.image_enhancer_combo, self.image_enhancers)
 
-        ocr_widget, self.ocr_combo = create_title_and_combo(self.tr("OCR"), self.ocr_engines, h4=True)
+        ocr_widget, self.ocr_combo = create_title_and_combo(
+            self.tr("OCR"),
+            self.ocr_engines,
+            h4=True,
+        )
         set_combo_box_width(self.ocr_combo, self.ocr_engines)
 
-        detector_widget, self.detector_combo = create_title_and_combo(self.tr("Text Detector"), self.detectors, h4=True)
+        detector_widget, self.detector_combo = create_title_and_combo(
+            self.tr("Text Detector"),
+            self.detectors,
+            h4=True,
+        )
         set_combo_box_width(self.detector_combo, self.detectors)
 
         inpainting_label = MLabel(self.tr("Inpainting")).h4()
-        inpainter_widget, self.inpainter_combo = create_title_and_combo(self.tr("Inpainter"), self.inpainters, h4=False)
+        inpainter_widget, self.inpainter_combo = create_title_and_combo(
+            self.tr("Inpainter"),
+            self.inpainters,
+            h4=False,
+        )
         set_combo_box_width(self.inpainter_combo, self.inpainters)
         self.inpainter_combo.setCurrentText(self.tr("AOT"))
 
-        inpaint_strategy_widget, self.inpaint_strategy_combo = create_title_and_combo(self.tr("HD Strategy"), self.inpaint_strategy, h4=False)
+        inpaint_strategy_widget, self.inpaint_strategy_combo = create_title_and_combo(
+            self.tr("HD Strategy"),
+            self.inpaint_strategy,
+            h4=False,
+        )
         set_combo_box_width(self.inpaint_strategy_combo, self.inpaint_strategy)
         self.inpaint_strategy_combo.setCurrentText(self.tr("Resize"))
 
-        # HD Strategy detail widgets
         self.hd_strategy_widgets = QtWidgets.QWidget()
         self.hd_strategy_layout = QtWidgets.QVBoxLayout(self.hd_strategy_widgets)
 
-        # Resize panel
         self.resize_widget = QtWidgets.QWidget()
         about_resize_layout = QtWidgets.QVBoxLayout(self.resize_widget)
         resize_layout = QtWidgets.QHBoxLayout()
         resize_label = MLabel(self.tr("Resize Limit:"))
-        about_resize_label = MLabel(self.tr("Resize the longer side of the image to a specific size,\nthen do inpainting on the resized image."))
+        about_resize_label = MLabel(
+            self.tr(
+                "Resize the longer side of the image to a specific size,\n"
+                "then do inpainting on the resized image."
+            )
+        )
         self.resize_spinbox = MSpinBox().small()
         self.resize_spinbox.setFixedWidth(70)
         self.resize_spinbox.setMaximum(3000)
@@ -68,10 +98,11 @@ class ToolsPage(QtWidgets.QWidget):
         about_resize_layout.setContentsMargins(5, 5, 5, 5)
         about_resize_layout.addStretch()
 
-        # Crop panel
         self.crop_widget = QtWidgets.QWidget()
         crop_layout = QtWidgets.QVBoxLayout(self.crop_widget)
-        about_crop_label = MLabel(self.tr("Crop masking area from the original image to do inpainting."))
+        about_crop_label = MLabel(
+            self.tr("Crop masking area from the original image to do inpainting.")
+        )
         crop_margin_layout = QtWidgets.QHBoxLayout()
         crop_margin_label = MLabel(self.tr("Crop Margin:"))
         self.crop_margin_spinbox = MSpinBox().small()
@@ -102,7 +133,9 @@ class ToolsPage(QtWidgets.QWidget):
 
         self.resize_widget.show()
         self.crop_widget.hide()
-        self.inpaint_strategy_combo.currentIndexChanged.connect(self._update_hd_strategy_widgets)
+        self.inpaint_strategy_combo.currentIndexChanged.connect(
+            self._update_hd_strategy_widgets
+        )
 
         self.use_gpu_checkbox = MCheckBox(self.tr("Use GPU"))
 
@@ -123,11 +156,13 @@ class ToolsPage(QtWidgets.QWidget):
 
         self._update_hd_strategy_widgets(self.inpaint_strategy_combo.currentIndex())
 
-    def _update_hd_strategy_widgets(self, index: int):
+    def _update_hd_strategy_widgets(self, index: int) -> None:
         strategy = self.inpaint_strategy_combo.itemText(index)
         self.resize_widget.setVisible(strategy == self.tr("Resize"))
         self.crop_widget.setVisible(strategy == self.tr("Crop"))
         if strategy == self.tr("Original"):
             self.hd_strategy_widgets.setFixedHeight(0)
         else:
-            self.hd_strategy_widgets.setFixedHeight(self.hd_strategy_widgets.sizeHint().height())
+            self.hd_strategy_widgets.setFixedHeight(
+                self.hd_strategy_widgets.sizeHint().height()
+            )


### PR DESCRIPTION
## Summary
- rebuild the tools page widget to resolve indentation problems
- add an Image Enhancer dropdown with default options and width adjustments
- keep HD strategy controls functional with explicit visibility handling

## Testing
- python -m compileall app/ui/settings/tools_page.py

------
https://chatgpt.com/codex/tasks/task_e_68e2f40b7b888330bcfc1cb41070faf8