### PR TITLE
Add WFWF import workflow

### DIFF
--- a/app/ui/dialogs/__init__.py
+++ b/app/ui/dialogs/__init__.py
@@ -1,0 +1,1 @@
+"""Dialog widgets used across the Comic Translate UI."""

--- a/app/ui/dialogs/import_wfwf_dialog.py
+++ b/app/ui/dialogs/import_wfwf_dialog.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import mimetypes
+import os
+import shutil
+import tempfile
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+from PySide6 import QtCore, QtGui, QtWidgets
+
+
+class ImportDownloadWorker(QtCore.QThread):
+    """Worker thread responsible for downloading images from a WFWF URL."""
+
+    progress = QtCore.Signal(int, int)
+    error = QtCore.Signal(str)
+    completed = QtCore.Signal(list)
+
+    def __init__(self, url: str, temp_dir: str, parent: QtCore.QObject | None = None) -> None:
+        super().__init__(parent)
+        self.url = url
+        self.temp_dir = temp_dir
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/122.0 Safari/537.36"
+                ),
+                "Referer": url,
+                "Accept-Language": "en-US,en;q=0.9",
+            }
+        )
+
+    def _guess_extension(self, img_url: str, response: requests.Response) -> str:
+        parsed = urlparse(img_url)
+        ext = os.path.splitext(parsed.path)[1].lower()
+        valid_exts = {".jpg", ".jpeg", ".png", ".webp", ".bmp", ".gif"}
+        if ext in valid_exts:
+            return ".jpg" if ext == ".jpeg" else ext
+
+        mime_ext = mimetypes.guess_extension(response.headers.get("Content-Type", ""))
+        if mime_ext:
+            mime_ext = ".jpg" if mime_ext == ".jpe" else mime_ext
+            if mime_ext in valid_exts:
+                return mime_ext
+        return ".jpg"
+
+    def run(self) -> None:  # noqa: D401
+        try:
+            response = self._session.get(self.url, timeout=30)
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            self.error.emit(str(exc))
+            return
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        images = soup.find_all("img", class_="v-img lazyload")
+        candidate_urls = []
+        for img in images:
+            src = img.attrs.get("data-original") or img.attrs.get("src")
+            if not src:
+                continue
+            candidate_urls.append(urljoin(self.url, src))
+
+        # Deduplicate while preserving order
+        seen: set[str] = set()
+        download_urls: list[str] = []
+        for candidate in candidate_urls:
+            if candidate not in seen:
+                seen.add(candidate)
+                download_urls.append(candidate)
+
+        if not download_urls:
+            self.error.emit("No downloadable images were found at the provided URL.")
+            return
+
+        total = len(download_urls)
+        downloaded_files: list[str] = []
+        for index, img_url in enumerate(download_urls, start=1):
+            try:
+                img_response = self._session.get(img_url, timeout=60)
+                img_response.raise_for_status()
+            except requests.RequestException as exc:
+                self.error.emit(str(exc))
+                return
+
+            extension = self._guess_extension(img_url, img_response)
+            filename = f"{index:04d}{extension}"
+            img_path = os.path.join(self.temp_dir, filename)
+            try:
+                with open(img_path, "wb") as handle:
+                    handle.write(img_response.content)
+            except OSError as exc:
+                self.error.emit(str(exc))
+                return
+
+            downloaded_files.append(img_path)
+            self.progress.emit(index, total)
+
+        self.completed.emit(downloaded_files)
+
+
+class ImportWFWFDialog(QtWidgets.QDialog):
+    """Dialog allowing the user to import images from a WFWF URL."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle(self.tr("Import from WFWF"))
+        self.setModal(True)
+
+        self.temp_dir = tempfile.mkdtemp(prefix="wfwf_import_")
+        self._cleanup_on_close = True
+        self.download_worker: ImportDownloadWorker | None = None
+        self._downloaded_files: list[str] = []
+
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+        description = QtWidgets.QLabel(
+            self.tr(
+                "Paste the WFWF chapter URL. The application will download and order "
+                "all images found on the page."
+            )
+        )
+        description.setWordWrap(True)
+        layout.addWidget(description)
+
+        self.url_input = QtWidgets.QLineEdit(self)
+        self.url_input.setPlaceholderText(self.tr("https://wfwf443.com/..."))
+        self.url_input.returnPressed.connect(self.start_download)
+        layout.addWidget(self.url_input)
+
+        self.progress_bar = QtWidgets.QProgressBar(self)
+        self.progress_bar.setRange(0, 0)
+        self.progress_bar.setVisible(False)
+        layout.addWidget(self.progress_bar)
+
+        self.status_label = QtWidgets.QLabel(self)
+        self.status_label.setVisible(False)
+        layout.addWidget(self.status_label)
+
+        self.button_box = QtWidgets.QDialogButtonBox(self)
+        self.import_button = self.button_box.addButton(
+            self.tr("Import"), QtWidgets.QDialogButtonBox.AcceptRole
+        )
+        self.cancel_button = self.button_box.addButton(
+            QtWidgets.QDialogButtonBox.Cancel
+        )
+        self.button_box.rejected.connect(self.reject)
+        self.import_button.clicked.connect(self.start_download)
+        layout.addWidget(self.button_box)
+
+    def start_download(self) -> None:
+        url = self.get_url()
+        if not url:
+            QtWidgets.QMessageBox.warning(
+                self,
+                self.tr("Missing URL"),
+                self.tr("Please enter a valid WFWF URL."),
+            )
+            return
+
+        if self.download_worker and self.download_worker.isRunning():
+            return
+
+        self._toggle_ui_for_download(True)
+        self.status_label.setText(self.tr("Fetching page..."))
+        self.status_label.setVisible(True)
+        self.progress_bar.setRange(0, 0)
+        self.progress_bar.setVisible(True)
+
+        self.download_worker = ImportDownloadWorker(url, self.temp_dir, self)
+        self.download_worker.progress.connect(self._on_progress)
+        self.download_worker.error.connect(self._on_error)
+        self.download_worker.completed.connect(self._on_completed)
+        self.download_worker.start()
+
+    def _toggle_ui_for_download(self, downloading: bool) -> None:
+        self.url_input.setEnabled(not downloading)
+        self.import_button.setEnabled(not downloading)
+        self.cancel_button.setEnabled(not downloading)
+
+    def _on_progress(self, current: int, total: int) -> None:
+        if self.progress_bar.maximum() != total:
+            self.progress_bar.setRange(0, total)
+        self.progress_bar.setValue(current)
+        self.status_label.setText(
+            self.tr("Downloading image {current} of {total}...").format(
+                current=current, total=total
+            )
+        )
+
+    def _on_error(self, message: str) -> None:
+        self._toggle_ui_for_download(False)
+        self.progress_bar.setVisible(False)
+        self.status_label.setVisible(False)
+        self.download_worker = None
+        QtWidgets.QMessageBox.critical(
+            self,
+            self.tr("Download failed"),
+            message,
+        )
+
+    def _on_completed(self, files: list[str]) -> None:
+        self._downloaded_files = files
+        self._cleanup_on_close = False
+        self.download_worker = None
+        self.accept()
+
+    def get_url(self) -> str:
+        return self.url_input.text().strip()
+
+    def get_temp_dir(self) -> str:
+        return self.temp_dir
+
+    def get_downloaded_files(self) -> list[str]:
+        return list(self._downloaded_files)
+
+    def cleanup(self) -> None:
+        if os.path.isdir(self.temp_dir):
+            shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def reject(self) -> None:
+        super().reject()
+        if self._cleanup_on_close:
+            self.cleanup()
+
+    def closeEvent(self, event: QtGui.QCloseEvent) -> None:  # type: ignore[override]
+        try:
+            if self._cleanup_on_close:
+                self.cleanup()
+        finally:
+            super().closeEvent(event)

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -190,6 +190,11 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
         project_action = self.tool_menu.addAction(MIcon("ct-file-icon.svg"), self.tr("Project File"))
         project_action.triggered.connect(self.project_browser_button.clicked)
 
+        self.tool_menu.addSeparator()
+        self.import_wfwf_action = self.tool_menu.addAction(
+            MIcon("cloud_line.svg"), self.tr("Import from WFWF")
+        )
+
         # Rest of the code remains the same
         self.save_browser = MClickSaveFileToolButton()
         save_file_types = [("Images", ["png", "jpg", "jpeg", "webp", "bmp"])]

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for project and import management."""

--- a/app/utils/project_processing.py
+++ b/app/utils/project_processing.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from typing import Iterable
+
+from PySide6 import QtWidgets
+
+from app.ui.dayu_widgets.message import MMessage
+from app.ui.dialogs.import_wfwf_dialog import ImportWFWFDialog
+
+
+def _copy_and_order_images(image_paths: Iterable[str]) -> list[str]:
+    """Copy downloaded images to a dedicated temp directory in order."""
+    project_dir = tempfile.mkdtemp(prefix="wfwf_project_")
+    ordered_files: list[str] = []
+
+    for index, src in enumerate(image_paths, start=1):
+        extension = os.path.splitext(src)[1] or ".jpg"
+        # Normalise jpeg extension
+        if extension.lower() == ".jpeg":
+            extension = ".jpg"
+        dest = os.path.join(project_dir, f"{index:04d}{extension}")
+        shutil.copy2(src, dest)
+        ordered_files.append(dest)
+
+    return ordered_files
+
+
+def import_from_wfwf(main_window: QtWidgets.QWidget) -> None:
+    """Launch the WFWF import dialog and load the downloaded images."""
+    dialog = ImportWFWFDialog(main_window)
+
+    if dialog.exec() != QtWidgets.QDialog.Accepted:
+        dialog.cleanup()
+        return
+
+    downloaded_files = dialog.get_downloaded_files()
+    if not downloaded_files:
+        dialog.cleanup()
+        MMessage.error(
+            text=main_window.tr("No images were downloaded from the provided URL."),
+            parent=main_window,
+            duration=None,
+            closable=True,
+        )
+        return
+
+    try:
+        ordered_files = _copy_and_order_images(downloaded_files)
+    except OSError as exc:
+        dialog.cleanup()
+        MMessage.error(
+            text=main_window.tr("Failed to prepare downloaded images: {error}").format(error=str(exc)),
+            parent=main_window,
+            duration=None,
+            closable=True,
+        )
+        return
+
+    dialog.cleanup()
+
+    main_window.image_ctrl.thread_load_images(ordered_files)
+    MMessage.success(
+        text=main_window.tr("WFWF images downloaded successfully."),
+        parent=main_window,
+        duration=3000,
+        closable=True,
+    )

--- a/controller.py
+++ b/controller.py
@@ -37,6 +37,8 @@ from app.controllers.text import TextController
 from app.controllers.webtoons import WebtoonController
 from collections import deque
 
+from app.utils.project_processing import import_from_wfwf as import_from_wfwf_util
+
 
 # Ensure any pre-declared mandatory models
 ensure_mandatory_models()
@@ -166,6 +168,9 @@ class ComicTranslate(ComicTranslateUI):
         self.change_all_blocks_size_inc.clicked.connect(lambda: self.text_ctrl.change_all_blocks_size(int(self.change_all_blocks_size_diff.text())))
         self.delete_button.clicked.connect(self.delete_selected_box)
 
+        if getattr(self, "import_wfwf_action", None):
+            self.import_wfwf_action.triggered.connect(self.import_from_wfwf)
+
         # Connect text edit widgets
         self.s_text_edit.textChanged.connect(self.text_ctrl.update_text_block)
         self.t_text_edit.textChanged.connect(self.text_ctrl.update_text_block_from_edit)
@@ -208,6 +213,10 @@ class ComicTranslate(ComicTranslateUI):
 
         # New project and safety confirmations
         self.new_project_button.clicked.connect(self._on_new_project_clicked)
+
+    def import_from_wfwf(self) -> None:
+        """Open the WFWF import dialog and load the resulting project."""
+        import_from_wfwf_util(self)
 
     def _guarded_thread_load_images(self, paths: list[str]):
         """Wrap thread_load_images with unsaved-project confirmation and clear state."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ setuptools
 PySide6>=6.8.0
 msgpack>=1.1.0
 requests>=2.31.0
+beautifulsoup4>=4.12.3
 pdfplumber>=0.11.5
 py7zr>=0.20.8
 rarfile>=4.1


### PR DESCRIPTION
## Summary
- add a WFWF import dialog and threaded worker to download chapter images
- integrate the WFWF import flow into the main window menu and controller logic
- introduce project-processing helpers and add BeautifulSoup as a dependency

## Testing
- python -m compileall app
- python -m compileall app/ui/dialogs/import_wfwf_dialog.py app/utils/project_processing.py controller.py app/ui/main_window.py

------
https://chatgpt.com/codex/tasks/task_e_68e4274402e08330b86781d7bf95a27b