### PR TITLE
Refine plain bubble handling in adaptive colours

### DIFF
--- a/app/controllers/text.py
+++ b/app/controllers/text.py
@@ -166,6 +166,14 @@ class TextController:
         underline = render_settings.underline
         direction = render_settings.direction
 
+        bubble_color = None
+        bubble_padding = float(getattr(blk, "bubble_padding", 0.0) or 0.0)
+        bubble_corner = float(getattr(blk, "bubble_corner_radius", 0.0) or 0.0)
+        bubble_rgba = getattr(blk, "bubble_fill_rgba", None)
+        if bubble_rgba:
+            r, g, b, a = bubble_rgba
+            bubble_color = QColor(int(r), int(g), int(b), int(a))
+
         properties = TextItemProperties(
             text=text,
             font_family=font_family,
@@ -181,6 +189,9 @@ class TextController:
             direction=direction,
             position=(blk.xyxy[0], blk.xyxy[1]),
             rotation=blk.angle,
+            bubble_fill=bubble_color,
+            bubble_padding=bubble_padding,
+            bubble_corner_radius=bubble_corner,
         )
         
         text_item = self.main.image_viewer.add_text_item(properties)

--- a/app/ui/canvas/image_viewer.py
+++ b/app/ui/canvas/image_viewer.py
@@ -387,20 +387,23 @@ class ImageViewer(QGraphicsView):
         # Create the TextBlockItem with the most up-to-date construction logic
         # Based on the load_state function which has the most complete setup
         item = TextBlockItem(
-            text=properties.text, 
+            text=properties.text,
             font_family=properties.font_family,
-            font_size=properties.font_size, 
+            font_size=properties.font_size,
             render_color=properties.text_color,
-            alignment=properties.alignment, 
+            alignment=properties.alignment,
             line_spacing=properties.line_spacing,
-            outline_color=properties.outline_color, 
+            outline_color=properties.outline_color,
             outline_width=properties.outline_width,
-            bold=properties.bold, 
-            italic=properties.italic, 
+            bold=properties.bold,
+            italic=properties.italic,
             underline=properties.underline,
             direction=properties.direction,
+            bubble_fill=properties.bubble_fill,
+            bubble_padding=properties.bubble_padding,
+            bubble_corner_radius=properties.bubble_corner_radius,
         )
-        
+
         # Apply width if specified
         if properties.width is not None:
             item.set_text(properties.text, properties.width)

--- a/app/ui/canvas/save_renderer.py
+++ b/app/ui/canvas/save_renderer.py
@@ -50,6 +50,9 @@ class ImageSaveRenderer:
                 italic=text_props.italic,
                 underline=text_props.underline,
                 direction=text_props.direction,
+                bubble_fill=text_props.bubble_fill,
+                bubble_padding=text_props.bubble_padding,
+                bubble_corner_radius=text_props.bubble_corner_radius,
             )
 
             text_item.set_text(text_props.text, text_props.width)

--- a/app/ui/canvas/text/text_item_properties.py
+++ b/app/ui/canvas/text/text_item_properties.py
@@ -18,7 +18,10 @@ class TextItemProperties:
     italic: bool = False
     underline: bool = False
     direction: Qt.LayoutDirection = Qt.LayoutDirection.LeftToRight
-    
+    bubble_fill: Optional[QColor] = None
+    bubble_padding: float = 0.0
+    bubble_corner_radius: float = 12.0
+
     # Position and transformation properties
     position: tuple = (0, 0)  # (x, y)
     rotation: float = 0
@@ -60,7 +63,16 @@ class TextItemProperties:
                 props.outline_color = QColor(data['outline_color'])
                 
         props.outline_width = data.get('outline_width', 1)
-        
+
+        if 'bubble_fill' in data:
+            bubble_val = data.get('bubble_fill')
+            if isinstance(bubble_val, QColor):
+                props.bubble_fill = bubble_val
+            elif bubble_val:
+                props.bubble_fill = QColor(bubble_val)
+        props.bubble_padding = data.get('bubble_padding', 0.0)
+        props.bubble_corner_radius = data.get('bubble_corner_radius', 12.0)
+
         # Alignment
         if 'alignment' in data:
             if isinstance(data['alignment'], int):
@@ -101,11 +113,14 @@ class TextItemProperties:
         props.line_spacing = item.line_spacing
         props.outline_color = item.outline_color
         props.outline_width = item.outline_width
+        props.bubble_fill = QColor(item.bubble_fill) if getattr(item, 'bubble_fill', None) else None
+        props.bubble_padding = getattr(item, 'bubble_padding', 0.0)
+        props.bubble_corner_radius = getattr(item, 'bubble_corner_radius', 12.0)
         props.bold = item.bold
         props.italic = item.italic
         props.underline = item.underline
         props.direction = item.direction
-        
+
         # Position and transformation
         props.position = (item.pos().x(), item.pos().y())
         props.rotation = item.rotation()
@@ -115,12 +130,13 @@ class TextItemProperties:
             props.transform_origin = (origin.x(), origin.y())
         
         # Layout properties
-        props.width = item.boundingRect().width()
+        width = item.textWidth()
+        props.width = width if width > 0 else item.boundingRect().width()
         props.vertical = getattr(item, 'vertical', False)
-        
+
         # Advanced properties
         props.selection_outlines = getattr(item, 'selection_outlines', []).copy()
-        
+
         return props
     
     def to_dict(self) -> dict:
@@ -138,6 +154,9 @@ class TextItemProperties:
             'italic': self.italic,
             'underline': self.underline,
             'direction': self.direction,
+            'bubble_fill': self.bubble_fill,
+            'bubble_padding': self.bubble_padding,
+            'bubble_corner_radius': self.bubble_corner_radius,
             'position': self.position,
             'rotation': self.rotation,
             'scale': self.scale,

--- a/app/ui/commands/base.py
+++ b/app/ui/commands/base.py
@@ -217,9 +217,12 @@ class RectCommandBase:
                     is_close(item.rotation(), properties.rotation) and
                     is_close(item.scale(), properties.scale) and
                     is_close(item.transformOriginPoint().x(), properties.transform_origin[0]) and
-                    is_close(item.transformOriginPoint().y(), properties.transform_origin[1]) and
-                    is_close(item.boundingRect().width(), properties.width)):
-                    return item
+                    is_close(item.transformOriginPoint().y(), properties.transform_origin[1])):
+                    item_width = item.textWidth()
+                    if item_width <= 0:
+                        item_width = item.boundingRect().width()
+                    if is_close(item_width, properties.width):
+                        return item
         return None
 
 

--- a/modules/rendering/render.py
+++ b/modules/rendering/render.py
@@ -351,10 +351,22 @@ def manual_wrap(
         if decision:
             blk.font_color = decision.text_hex
             blk.outline_color = decision.outline_hex
+            if decision.bubble_fill_rgba:
+                blk.bubble_fill_rgba = decision.bubble_fill_rgba
+                shorter = max(1.0, min(width, height))
+                blk.bubble_padding = max(6.0, shorter * 0.08)
+                blk.bubble_corner_radius = max(10.0, shorter * 0.18)
+            else:
+                blk.bubble_fill_rgba = None
+                blk.bubble_padding = 0.0
+                blk.bubble_corner_radius = 0.0
         else:
             blk.font_color = blk.font_color or default_text_color
             if not getattr(blk, 'outline_color', ''):
                 blk.outline_color = default_outline_color if render_settings.outline else ''
+            blk.bubble_fill_rgba = None
+            blk.bubble_padding = 0.0
+            blk.bubble_corner_radius = 0.0
 
         translation, font_size = pyside_word_wrap(translation, font_family, width, height,
                                                  line_spacing, outline_width, bold, italic, underline,

--- a/pipeline/batch_processor.py
+++ b/pipeline/batch_processor.py
@@ -370,6 +370,15 @@ class BatchProcessor:
                     blk.outline_color = decision.outline_hex
                     text_color = QColor(decision.text_hex)
                     outline_color = QColor(decision.outline_hex)
+                    if getattr(decision, 'bubble_fill_rgba', None):
+                        blk.bubble_fill_rgba = decision.bubble_fill_rgba
+                        shorter = max(1.0, min(width, height))
+                        blk.bubble_padding = max(6.0, shorter * 0.08)
+                        blk.bubble_corner_radius = max(10.0, shorter * 0.18)
+                    else:
+                        blk.bubble_fill_rgba = None
+                        blk.bubble_padding = 0.0
+                        blk.bubble_corner_radius = 0.0
                 else:
                     if not getattr(blk, 'font_color', ''):
                         blk.font_color = default_text_color.name()
@@ -381,6 +390,9 @@ class BatchProcessor:
                         outline_color = QColor(blk.outline_color)
                     else:
                         outline_color = default_outline_color
+                    blk.bubble_fill_rgba = None
+                    blk.bubble_padding = 0.0
+                    blk.bubble_corner_radius = 0.0
 
                 outline_enabled = render_settings.outline or bool(decision) or bool(getattr(blk, 'outline_color', ''))
 
@@ -393,6 +405,14 @@ class BatchProcessor:
                     translation = translation.replace(' ', '')
 
                 # Use TextItemProperties for consistent text item creation
+                bubble_qcolor = None
+                bubble_rgba = getattr(blk, 'bubble_fill_rgba', None)
+                if bubble_rgba:
+                    r, g, b, a = bubble_rgba
+                    bubble_qcolor = QColor(int(r), int(g), int(b), int(a))
+                bubble_padding = float(getattr(blk, 'bubble_padding', 0.0) or 0.0)
+                bubble_corner = float(getattr(blk, 'bubble_corner_radius', 0.0) or 0.0)
+
                 text_props = TextItemProperties(
                     text=translation,
                     font_family=font,
@@ -411,6 +431,9 @@ class BatchProcessor:
                     transform_origin=blk.tr_origin_point,
                     width=width,
                     direction=direction,
+                    bubble_fill=bubble_qcolor,
+                    bubble_padding=bubble_padding,
+                    bubble_corner_radius=bubble_corner,
                     selection_outlines=[
                         OutlineInfo(0, len(translation),
                         outline_color,

--- a/pipeline/webtoon_batch_processor.py
+++ b/pipeline/webtoon_batch_processor.py
@@ -827,6 +827,15 @@ class WebtoonBatchProcessor:
                 blk_virtual.outline_color = decision.outline_hex
                 text_color = QColor(decision.text_hex)
                 outline_color = QColor(decision.outline_hex)
+                if getattr(decision, 'bubble_fill_rgba', None):
+                    blk_virtual.bubble_fill_rgba = decision.bubble_fill_rgba
+                    shorter = max(1.0, min(width, height))
+                    blk_virtual.bubble_padding = max(6.0, shorter * 0.08)
+                    blk_virtual.bubble_corner_radius = max(10.0, shorter * 0.18)
+                else:
+                    blk_virtual.bubble_fill_rgba = None
+                    blk_virtual.bubble_padding = 0.0
+                    blk_virtual.bubble_corner_radius = 0.0
             else:
                 if not getattr(blk_virtual, 'font_color', ''):
                     blk_virtual.font_color = default_text_color.name()
@@ -838,6 +847,9 @@ class WebtoonBatchProcessor:
                     outline_color = QColor(blk_virtual.outline_color)
                 else:
                     outline_color = default_outline_color
+                blk_virtual.bubble_fill_rgba = None
+                blk_virtual.bubble_padding = 0.0
+                blk_virtual.bubble_corner_radius = 0.0
 
             outline_enabled = outline or bool(decision) or bool(getattr(blk_virtual, 'outline_color', ''))
 
@@ -865,6 +877,14 @@ class WebtoonBatchProcessor:
             # Language-specific formatting for State Storage
 
             # Use TextItemProperties for consistent text item creation
+            bubble_qcolor = None
+            bubble_rgba = getattr(render_blk, 'bubble_fill_rgba', None)
+            if bubble_rgba:
+                r, g, b, a = bubble_rgba
+                bubble_qcolor = QColor(int(r), int(g), int(b), int(a))
+            bubble_padding = float(getattr(render_blk, 'bubble_padding', 0.0) or 0.0)
+            bubble_corner = float(getattr(render_blk, 'bubble_corner_radius', 0.0) or 0.0)
+
             text_props = TextItemProperties(
                 text=translation,
                 font_family=font,
@@ -883,6 +903,9 @@ class WebtoonBatchProcessor:
                 transform_origin=blk_virtual.tr_origin_point if blk_virtual.tr_origin_point else (0, 0),
                 width=width,
                 direction=direction,
+                bubble_fill=bubble_qcolor,
+                bubble_padding=bubble_padding,
+                bubble_corner_radius=bubble_corner,
                 selection_outlines=[
                     OutlineInfo(
                         0,


### PR DESCRIPTION
## Summary
- extend the adaptive colour classifier to track light and dark coverage so plain white or black bubbles short-circuit to pure text colours
- expose the new plain-background heuristics by recording light/dark fractions in the sampling statistics and falling back to the legacy translucent bubble only when required
- expand the adaptive colour tests to cover uniform white and black bubbles with foreground lettering and to document the updated no-bubble expectation on flat panels

## Testing
- pytest tests/test_adaptive_color.py

------
https://chatgpt.com/codex/tasks/task_e_68e52ddf89348330947f29b957d65b9a