### PR TITLE
Add dynamic speech bubble rendering

### DIFF
--- a/app/controllers/image.py
+++ b/app/controllers/image.py
@@ -578,6 +578,7 @@ class ImageStateController:
                     self.main.rect_item_ctrl.connect_rect_item_signals(rect_item)
 
                 self.load_patch_state(file_path)
+                self.main.text_ctrl.refresh_bubble_styles(recompute=True)
             else:
                 # New image - just set language preferences and clear everything else
                 self.main.blk_list = []

--- a/app/controllers/projects.py
+++ b/app/controllers/projects.py
@@ -243,6 +243,7 @@ class ProjectController:
         settings.setValue('bubble_flat_var', float(bubble_cfg.get('bubble_flat_var', 8e-4)))
         settings.setValue('bubble_plain_alpha', int(bubble_cfg.get('bubble_plain_alpha', 230)))
         settings.setValue('text_target_contrast', float(bubble_cfg.get('text_target_contrast', 4.5)))
+        settings.setValue('bubble_text_alpha', int(bubble_cfg.get('bubble_text_alpha', 255)))
         settings.setValue('bubble_gradient_enabled', bool(bubble_cfg.get('bubble_gradient_enabled', False)))
         settings.setValue('bubble_gradient_start', list(bubble_cfg.get('bubble_gradient_start', (35, 100, 160))))
         settings.setValue('bubble_gradient_end', list(bubble_cfg.get('bubble_gradient_end', (200, 220, 255))))
@@ -365,6 +366,7 @@ class ProjectController:
         bubble_flat_var = float(settings.value('bubble_flat_var', 8e-4))
         bubble_plain_alpha = int(settings.value('bubble_plain_alpha', 230, type=int))
         text_target_contrast = float(settings.value('text_target_contrast', 4.5))
+        bubble_text_alpha = int(settings.value('bubble_text_alpha', 255, type=int))
         bubble_gradient_enabled = settings.value('bubble_gradient_enabled', False, type=bool)
 
         def _parse_rgb(value, default):
@@ -412,6 +414,7 @@ class ProjectController:
                 'bubble_flat_var': bubble_flat_var,
                 'bubble_plain_alpha': bubble_plain_alpha,
                 'text_target_contrast': text_target_contrast,
+                'bubble_text_alpha': bubble_text_alpha,
                 'bubble_gradient_enabled': bubble_gradient_enabled,
                 'bubble_gradient_start': gradient_start,
                 'bubble_gradient_end': gradient_end,
@@ -450,6 +453,17 @@ class ProjectController:
             max_slider.blockSignals(True)
             max_slider.setValue(bubble_max_alpha)
             max_slider.blockSignals(False)
+
+        text_spin = getattr(self.main, 'bubble_text_alpha_spin', None)
+        if text_spin is not None:
+            text_spin.blockSignals(True)
+            text_spin.setValue(bubble_text_alpha)
+            text_spin.blockSignals(False)
+        text_slider = getattr(self.main, 'bubble_text_alpha_slider', None)
+        if text_slider is not None:
+            text_slider.blockSignals(True)
+            text_slider.setValue(bubble_text_alpha)
+            text_slider.blockSignals(False)
 
         plain_spin = getattr(self.main, 'bubble_plain_alpha_spin', None)
         if plain_spin is not None:

--- a/app/controllers/projects.py
+++ b/app/controllers/projects.py
@@ -383,6 +383,34 @@ class ProjectController:
                 'text_target_contrast': text_target_contrast,
             }
         )
+
+        color_button = getattr(self.main, 'bubble_color_button', None)
+        if color_button is not None:
+            bubble_hex = '#{0:02X}{1:02X}{2:02X}'.format(*bubble_rgb)
+            color_button.blockSignals(True)
+            color_button.setStyleSheet(
+                f"background-color: {bubble_hex}; border: none; border-radius: 5px;"
+            )
+            color_button.setProperty('selected_color', bubble_hex)
+            color_button.blockSignals(False)
+
+        min_spin = getattr(self.main, 'bubble_min_alpha_spin', None)
+        if min_spin is not None:
+            min_spin.blockSignals(True)
+            min_spin.setValue(bubble_min_alpha)
+            min_spin.blockSignals(False)
+
+        max_spin = getattr(self.main, 'bubble_max_alpha_spin', None)
+        if max_spin is not None:
+            max_spin.blockSignals(True)
+            max_spin.setValue(bubble_max_alpha)
+            max_spin.blockSignals(False)
+
+        plain_spin = getattr(self.main, 'bubble_plain_alpha_spin', None)
+        if plain_spin is not None:
+            plain_spin.blockSignals(True)
+            plain_spin.setValue(bubble_plain_alpha)
+            plain_spin.blockSignals(False)
         settings.endGroup()
 
     def process_group(self, group_key, group_value, settings_obj: QSettings):

--- a/app/controllers/rect_item.py
+++ b/app/controllers/rect_item.py
@@ -9,7 +9,7 @@ from app.ui.canvas.rectangle import MoveableRectItem
 from app.ui.commands.box import AddRectangleCommand, BoxesChangeCommand
 
 from modules.detection.utils.geometry import do_rectangles_overlap
-from modules.utils.textblock import TextBlock
+from modules.utils.textblock import TextBlock, update_block_bounds
 
 if TYPE_CHECKING:
     from controller import ComicTranslate
@@ -68,10 +68,15 @@ class RectItemController:
         for blk in self.main.blk_list:
             if do_rectangles_overlap(blk.xyxy, old_rect_coords, 0.2):
                 # Update the TextBlock coordinates
-                blk.xyxy[:] = [int(new_rect_coords[0]), 
-                               int(new_rect_coords[1]),
-                               int(new_rect_coords[2]), 
-                               int(new_rect_coords[3])]
+                update_block_bounds(
+                    blk,
+                    [
+                        int(new_rect_coords[0]),
+                        int(new_rect_coords[1]),
+                        int(new_rect_coords[2]),
+                        int(new_rect_coords[3]),
+                    ],
+                )
                 blk.angle = new_angle if new_angle else 0
                 blk.tr_origin_point = (new_tr_origin.x(), new_tr_origin.y()) if new_tr_origin else ()
                 break

--- a/app/controllers/text.py
+++ b/app/controllers/text.py
@@ -323,6 +323,7 @@ class TextController:
 
         command = AddTextItemCommand(self.main, text_item)
         self.main.push_command(command)
+        self.refresh_bubble_styles(recompute=True)
 
     def on_text_item_selected(self, text_item: TextBlockItem):
         self.main.curr_tblock_item = text_item

--- a/app/controllers/text.py
+++ b/app/controllers/text.py
@@ -614,6 +614,41 @@ class TextController:
         target_lang = self.main.lang_mapping.get(self.main.t_combo.currentText(), None)
         direction = get_layout_direction(target_lang)
 
+        bubble_mode = 'auto'
+        if hasattr(self.main, 'bubble_mode_combo'):
+            combo = self.main.bubble_mode_combo
+            data = combo.currentData()
+            bubble_mode = (data or combo.currentText() or 'auto').lower()
+
+        bubble_config = getattr(self.main, 'bubble_style_config', {})
+        bubble_rgb = bubble_config.get('bubble_rgb', (35, 100, 160))
+        if isinstance(bubble_rgb, (list, tuple)):
+            bubble_rgb = tuple(int(v) for v in bubble_rgb[:3])
+        else:
+            bubble_rgb = (35, 100, 160)
+        bubble_min_alpha = int(bubble_config.get('bubble_min_alpha', 110))
+        bubble_max_alpha = int(bubble_config.get('bubble_max_alpha', 205))
+        bubble_plain_hi = float(bubble_config.get('bubble_plain_hi', 0.88))
+        bubble_plain_lo = float(bubble_config.get('bubble_plain_lo', 0.12))
+        bubble_flat_var = float(bubble_config.get('bubble_flat_var', 8e-4))
+        bubble_plain_alpha = int(bubble_config.get('bubble_plain_alpha', 230))
+        text_target_contrast = float(bubble_config.get('text_target_contrast', 4.5))
+
+        # Keep the configuration in sync so project saves persist overrides
+        self.main.bubble_style_config.update(
+            {
+                'bubble_mode': bubble_mode,
+                'bubble_rgb': bubble_rgb,
+                'bubble_min_alpha': bubble_min_alpha,
+                'bubble_max_alpha': bubble_max_alpha,
+                'bubble_plain_hi': bubble_plain_hi,
+                'bubble_plain_lo': bubble_plain_lo,
+                'bubble_flat_var': bubble_flat_var,
+                'bubble_plain_alpha': bubble_plain_alpha,
+                'text_target_contrast': text_target_contrast,
+            }
+        )
+
         return TextRenderingSettings(
             alignment_id = self.main.alignment_tool_group.get_dayu_checked(),
             font_family = self.main.font_dropdown.currentText(),
@@ -628,5 +663,14 @@ class TextController:
             italic = self.main.italic_button.isChecked(),
             underline = self.main.underline_button.isChecked(),
             line_spacing = self.main.line_spacing_dropdown.currentText(),
-            direction = direction
+            direction = direction,
+            bubble_mode = bubble_mode,
+            bubble_rgb = bubble_rgb,
+            bubble_min_alpha = bubble_min_alpha,
+            bubble_max_alpha = bubble_max_alpha,
+            bubble_plain_hi = bubble_plain_hi,
+            bubble_plain_lo = bubble_plain_lo,
+            bubble_flat_var = bubble_flat_var,
+            bubble_plain_alpha = bubble_plain_alpha,
+            text_target_contrast = text_target_contrast,
         )

--- a/app/controllers/text.py
+++ b/app/controllers/text.py
@@ -14,7 +14,7 @@ from app.ui.commands.box import AddTextItemCommand
 from app.ui.canvas.text_item import TextBlockItem
 from app.ui.canvas.text.text_item_properties import TextItemProperties
 
-from modules.utils.textblock import TextBlock
+from modules.utils.textblock import TextBlock, update_block_bounds
 from modules.rendering.render import TextRenderingSettings, manual_wrap
 from modules.rendering.dynamic_bubble import (
     compute_dynamic_bubble_style,
@@ -386,7 +386,13 @@ class TextController:
         updated_blk_list = []
         for blk in self.main.blk_list:
             blk_rect = tuple(blk.xyxy)
-            blk.xyxy[:] = [blk_rect[0] - diff, blk_rect[1] - diff, blk_rect[2] + diff, blk_rect[3] + diff]
+            new_coords = [
+                blk_rect[0] - diff,
+                blk_rect[1] - diff,
+                blk_rect[2] + diff,
+                blk_rect[3] + diff,
+            ]
+            update_block_bounds(blk, new_coords)
             updated_blk_list.append(blk)
         self.main.blk_list = updated_blk_list
         self.main.pipeline.load_box_coords(self.main.blk_list)

--- a/app/controllers/text.py
+++ b/app/controllers/text.py
@@ -158,13 +158,14 @@ class TextController:
         alignment = self.main.button_to_alignment[id]
         line_spacing = float(render_settings.line_spacing)
         outline_color_str = blk.outline_color if getattr(blk, 'outline_color', '') else render_settings.outline_color
-        outline_enabled = render_settings.outline or bool(getattr(blk, 'outline_color', ''))
+        outline_enabled = render_settings.outline or bool(getattr(blk, 'outline_color', '')) or bool(getattr(blk, 'bubble_style', None))
         outline_color = QColor(outline_color_str) if outline_enabled else None
-        outline_width = float(render_settings.outline_width)
+        outline_width = float(getattr(blk, 'outline_width', render_settings.outline_width))
         bold = render_settings.bold
         italic = render_settings.italic
         underline = render_settings.underline
         direction = render_settings.direction
+        bubble_style = getattr(blk, 'bubble_style', None)
 
         properties = TextItemProperties(
             text=text,
@@ -179,6 +180,7 @@ class TextController:
             italic=italic,
             underline=underline,
             direction=direction,
+            bubble_style=bubble_style,
             position=(blk.xyxy[0], blk.xyxy[1]),
             rotation=blk.angle,
         )

--- a/app/ui/canvas/image_viewer.py
+++ b/app/ui/canvas/image_viewer.py
@@ -387,18 +387,19 @@ class ImageViewer(QGraphicsView):
         # Create the TextBlockItem with the most up-to-date construction logic
         # Based on the load_state function which has the most complete setup
         item = TextBlockItem(
-            text=properties.text, 
+            text=properties.text,
             font_family=properties.font_family,
-            font_size=properties.font_size, 
+            font_size=properties.font_size,
             render_color=properties.text_color,
-            alignment=properties.alignment, 
+            alignment=properties.alignment,
             line_spacing=properties.line_spacing,
-            outline_color=properties.outline_color, 
+            outline_color=properties.outline_color,
             outline_width=properties.outline_width,
-            bold=properties.bold, 
-            italic=properties.italic, 
+            bold=properties.bold,
+            italic=properties.italic,
             underline=properties.underline,
             direction=properties.direction,
+            bubble_style=properties.bubble_style,
         )
         
         # Apply width if specified

--- a/app/ui/canvas/save_renderer.py
+++ b/app/ui/canvas/save_renderer.py
@@ -50,6 +50,7 @@ class ImageSaveRenderer:
                 italic=text_props.italic,
                 underline=text_props.underline,
                 direction=text_props.direction,
+                bubble_style=text_props.bubble_style,
             )
 
             text_item.set_text(text_props.text, text_props.width)

--- a/app/ui/canvas/text/text_item_properties.py
+++ b/app/ui/canvas/text/text_item_properties.py
@@ -12,6 +12,18 @@ def _normalize_bubble_style(style):
     for key, value in style.items():
         if isinstance(value, list):
             normalised[key] = tuple(value)
+        elif key == 'fill_gradient' and isinstance(value, dict):
+            grad_norm = {}
+            for gk, gv in value.items():
+                if gk in {'start_rgba', 'end_rgba'} and isinstance(gv, (list, tuple)):
+                    grad_norm[gk] = tuple(int(v) for v in gv)
+                elif gk == 'angle':
+                    grad_norm[gk] = float(gv)
+                elif isinstance(gv, list):
+                    grad_norm[gk] = tuple(gv)
+                else:
+                    grad_norm[gk] = gv
+            normalised[key] = grad_norm
         else:
             normalised[key] = value
     return normalised
@@ -149,6 +161,15 @@ class TextItemProperties:
             for key in ('fill_rgba', 'text_rgb', 'outline_rgb', 'shadow_rgba', 'shadow_offset', 'padding'):
                 if key in bubble_style and isinstance(bubble_style[key], tuple):
                     bubble_style[key] = list(bubble_style[key])
+            gradient = bubble_style.get('fill_gradient') if bubble_style else None
+            if isinstance(gradient, dict):
+                gradient_copy = {}
+                for gk, gv in gradient.items():
+                    if isinstance(gv, tuple):
+                        gradient_copy[gk] = list(gv)
+                    else:
+                        gradient_copy[gk] = gv
+                bubble_style['fill_gradient'] = gradient_copy
 
         return {
             'text': self.text,

--- a/app/ui/canvas/text/text_item_properties.py
+++ b/app/ui/canvas/text/text_item_properties.py
@@ -24,6 +24,8 @@ def _normalize_bubble_style(style):
                 else:
                     grad_norm[gk] = gv
             normalised[key] = grad_norm
+        elif key == 'text_alpha':
+            normalised[key] = int(value)
         else:
             normalised[key] = value
     return normalised

--- a/app/ui/canvas/text_item.py
+++ b/app/ui/canvas/text_item.py
@@ -137,6 +137,8 @@ class TextBlockItem(QGraphicsTextItem):
                 normalised[key] = gradient_norm
             elif key == 'corner_radius':
                 normalised[key] = float(value)
+            elif key == 'text_alpha':
+                normalised[key] = int(value)
             else:
                 normalised[key] = value
 

--- a/app/ui/commands/base.py
+++ b/app/ui/commands/base.py
@@ -209,6 +209,7 @@ class RectCommandBase:
                     is_close(item.line_spacing, properties.line_spacing) and
                     item.outline_color == properties.outline_color and
                     is_close(item.outline_width, properties.outline_width) and
+                    getattr(item, 'bubble_style', None) == getattr(properties, 'bubble_style', None) and
                     item.bold == properties.bold and
                     item.italic == properties.italic and
                     item.underline == properties.underline and

--- a/app/ui/commands/box.py
+++ b/app/ui/commands/box.py
@@ -7,6 +7,7 @@ from PySide6.QtCore import QRectF, QPointF
 from .base import RectCommandBase
 from ..canvas.rectangle import MoveableRectItem
 from ..canvas.text_item import TextBlockItem
+from modules.utils.textblock import update_block_bounds
 
 
 class AddRectangleCommand(QUndoCommand, RectCommandBase):
@@ -66,7 +67,7 @@ class BoxesChangeCommand(QUndoCommand, RectCommandBase):
             if (np.array_equal(blk.xyxy, self.old_xyxy) and
                 blk.angle == self.old_angle):
 
-                blk.xyxy[:] = self.new_xyxy
+                update_block_bounds(blk, self.new_xyxy)
                 blk.angle = self.new_angle
                 blk.tr_origin_point = self.new_tr_origin
 
@@ -85,7 +86,7 @@ class BoxesChangeCommand(QUndoCommand, RectCommandBase):
             if (np.array_equal(blk.xyxy, self.new_xyxy) and
                 blk.angle == self.new_angle ):
 
-                blk.xyxy[:] = self.old_xyxy
+                update_block_bounds(blk, self.old_xyxy)
                 blk.angle = self.old_angle
                 blk.tr_origin_point = self.old_tr_origin
 

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -5,7 +5,7 @@ from PySide6.QtGui import QIntValidator
 from PySide6.QtCore import QSettings
 from PySide6.QtGui import QFont, QFontDatabase
 
-from .dayu_widgets import dayu_theme
+from .dayu_widgets import dayu_theme, MSpinBox
 from .dayu_widgets.divider import MDivider
 from .dayu_widgets.combo_box import MComboBox, MFontComboBox
 from .dayu_widgets.check_box import MCheckBox
@@ -528,12 +528,59 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
         outline_settings_layout.addWidget(self.outline_width_dropdown)
         outline_settings_layout.addStretch()
 
+        # Bubble styling controls
+        bubble_cfg = getattr(self, 'bubble_style_config', {
+            'bubble_rgb': (35, 100, 160),
+            'bubble_min_alpha': 110,
+            'bubble_max_alpha': 205,
+            'bubble_plain_alpha': 230,
+        })
+
+        bubble_settings_layout = QtWidgets.QGridLayout()
+        bubble_settings_layout.setHorizontalSpacing(8)
+        bubble_settings_layout.setVerticalSpacing(6)
+
+        bubble_color_label = QtWidgets.QLabel(self.tr('Bubble Color'))
+        self.bubble_color_button = QtWidgets.QPushButton()
+        self.bubble_color_button.setFixedSize(30, 30)
+        bubble_rgb = tuple(int(v) for v in bubble_cfg.get('bubble_rgb', (35, 100, 160))[:3])
+        bubble_hex = '#{0:02X}{1:02X}{2:02X}'.format(*bubble_rgb)
+        self.bubble_color_button.setStyleSheet(
+            f"background-color: {bubble_hex}; border: none; border-radius: 5px;"
+        )
+        self.bubble_color_button.setProperty('selected_color', bubble_hex)
+
+        bubble_min_alpha_label = QtWidgets.QLabel(self.tr('Min Alpha'))
+        self.bubble_min_alpha_spin = MSpinBox().small()
+        self.bubble_min_alpha_spin.setRange(0, 255)
+        self.bubble_min_alpha_spin.setValue(int(bubble_cfg.get('bubble_min_alpha', 110)))
+
+        bubble_max_alpha_label = QtWidgets.QLabel(self.tr('Max Alpha'))
+        self.bubble_max_alpha_spin = MSpinBox().small()
+        self.bubble_max_alpha_spin.setRange(0, 255)
+        self.bubble_max_alpha_spin.setValue(int(bubble_cfg.get('bubble_max_alpha', 205)))
+
+        bubble_plain_alpha_label = QtWidgets.QLabel(self.tr('Plain Alpha'))
+        self.bubble_plain_alpha_spin = MSpinBox().small()
+        self.bubble_plain_alpha_spin.setRange(0, 255)
+        self.bubble_plain_alpha_spin.setValue(int(bubble_cfg.get('bubble_plain_alpha', 230)))
+
+        bubble_settings_layout.addWidget(bubble_color_label, 0, 0)
+        bubble_settings_layout.addWidget(self.bubble_color_button, 0, 1)
+        bubble_settings_layout.addWidget(bubble_min_alpha_label, 1, 0)
+        bubble_settings_layout.addWidget(self.bubble_min_alpha_spin, 1, 1)
+        bubble_settings_layout.addWidget(bubble_max_alpha_label, 2, 0)
+        bubble_settings_layout.addWidget(self.bubble_max_alpha_spin, 2, 1)
+        bubble_settings_layout.addWidget(bubble_plain_alpha_label, 3, 0)
+        bubble_settings_layout.addWidget(self.bubble_plain_alpha_spin, 3, 1)
+
         rendering_divider_top = MDivider()
         rendering_divider_bottom = MDivider()
         text_render_layout.addWidget(rendering_divider_top)
         text_render_layout.addLayout(font_settings_layout)
         text_render_layout.addLayout(main_text_settings_layout)
         text_render_layout.addLayout(outline_settings_layout)
+        text_render_layout.addLayout(bubble_settings_layout)
         text_render_layout.addWidget(rendering_divider_bottom)
 
         # Tools Layout

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -554,25 +554,91 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
         self.bubble_min_alpha_spin = MSpinBox().small()
         self.bubble_min_alpha_spin.setRange(0, 255)
         self.bubble_min_alpha_spin.setValue(int(bubble_cfg.get('bubble_min_alpha', 110)))
+        self.bubble_min_alpha_slider = MSlider()
+        self.bubble_min_alpha_slider.setRange(0, 255)
+        self.bubble_min_alpha_slider.setValue(self.bubble_min_alpha_spin.value())
+        self.bubble_min_alpha_slider.setToolTip(self.tr('Minimum bubble opacity'))
 
         bubble_max_alpha_label = QtWidgets.QLabel(self.tr('Max Alpha'))
         self.bubble_max_alpha_spin = MSpinBox().small()
         self.bubble_max_alpha_spin.setRange(0, 255)
         self.bubble_max_alpha_spin.setValue(int(bubble_cfg.get('bubble_max_alpha', 205)))
+        self.bubble_max_alpha_slider = MSlider()
+        self.bubble_max_alpha_slider.setRange(0, 255)
+        self.bubble_max_alpha_slider.setValue(self.bubble_max_alpha_spin.value())
+        self.bubble_max_alpha_slider.setToolTip(self.tr('Maximum bubble opacity'))
 
         bubble_plain_alpha_label = QtWidgets.QLabel(self.tr('Plain Alpha'))
         self.bubble_plain_alpha_spin = MSpinBox().small()
         self.bubble_plain_alpha_spin.setRange(0, 255)
         self.bubble_plain_alpha_spin.setValue(int(bubble_cfg.get('bubble_plain_alpha', 230)))
+        self.bubble_plain_alpha_slider = MSlider()
+        self.bubble_plain_alpha_slider.setRange(0, 255)
+        self.bubble_plain_alpha_slider.setValue(self.bubble_plain_alpha_spin.value())
+        self.bubble_plain_alpha_slider.setToolTip(self.tr('Plain bubble opacity'))
+
+        gradient_enabled = bool(bubble_cfg.get('bubble_gradient_enabled', False))
+        gradient_start_rgb = tuple(int(v) for v in bubble_cfg.get('bubble_gradient_start', bubble_rgb))
+        gradient_end_rgb = tuple(int(v) for v in bubble_cfg.get('bubble_gradient_end', gradient_start_rgb))
+        gradient_angle = int(float(bubble_cfg.get('bubble_gradient_angle', 90.0)))
+
+        self.bubble_gradient_checkbox = MCheckBox(self.tr('Gradient Fill'))
+        self.bubble_gradient_checkbox.setChecked(gradient_enabled)
+
+        gradient_start_label = QtWidgets.QLabel(self.tr('Start'))
+        self.bubble_gradient_start_button = QtWidgets.QPushButton()
+        self.bubble_gradient_start_button.setFixedSize(30, 30)
+        start_hex = '#{0:02X}{1:02X}{2:02X}'.format(*gradient_start_rgb)
+        self.bubble_gradient_start_button.setStyleSheet(
+            f"background-color: {start_hex}; border: none; border-radius: 5px;"
+        )
+        self.bubble_gradient_start_button.setProperty('selected_color', start_hex)
+
+        gradient_end_label = QtWidgets.QLabel(self.tr('End'))
+        self.bubble_gradient_end_button = QtWidgets.QPushButton()
+        self.bubble_gradient_end_button.setFixedSize(30, 30)
+        end_hex = '#{0:02X}{1:02X}{2:02X}'.format(*gradient_end_rgb)
+        self.bubble_gradient_end_button.setStyleSheet(
+            f"background-color: {end_hex}; border: none; border-radius: 5px;"
+        )
+        self.bubble_gradient_end_button.setProperty('selected_color', end_hex)
+
+        gradient_angle_label = QtWidgets.QLabel(self.tr('Angle'))
+        self.bubble_gradient_angle_spin = MSpinBox().small()
+        self.bubble_gradient_angle_spin.setRange(0, 360)
+        self.bubble_gradient_angle_spin.setValue(gradient_angle)
+        self.bubble_gradient_angle_slider = MSlider()
+        self.bubble_gradient_angle_slider.setRange(0, 360)
+        self.bubble_gradient_angle_slider.setValue(gradient_angle)
+        self.bubble_gradient_angle_slider.setToolTip(self.tr('Gradient angle'))
+
+        for widget in (
+            self.bubble_gradient_start_button,
+            self.bubble_gradient_end_button,
+            self.bubble_gradient_angle_spin,
+            self.bubble_gradient_angle_slider,
+        ):
+            widget.setEnabled(gradient_enabled)
 
         bubble_settings_layout.addWidget(bubble_color_label, 0, 0)
         bubble_settings_layout.addWidget(self.bubble_color_button, 0, 1)
         bubble_settings_layout.addWidget(bubble_min_alpha_label, 1, 0)
         bubble_settings_layout.addWidget(self.bubble_min_alpha_spin, 1, 1)
+        bubble_settings_layout.addWidget(self.bubble_min_alpha_slider, 1, 2)
         bubble_settings_layout.addWidget(bubble_max_alpha_label, 2, 0)
         bubble_settings_layout.addWidget(self.bubble_max_alpha_spin, 2, 1)
+        bubble_settings_layout.addWidget(self.bubble_max_alpha_slider, 2, 2)
         bubble_settings_layout.addWidget(bubble_plain_alpha_label, 3, 0)
         bubble_settings_layout.addWidget(self.bubble_plain_alpha_spin, 3, 1)
+        bubble_settings_layout.addWidget(self.bubble_plain_alpha_slider, 3, 2)
+        bubble_settings_layout.addWidget(self.bubble_gradient_checkbox, 4, 0, 1, 3)
+        bubble_settings_layout.addWidget(gradient_start_label, 5, 0)
+        bubble_settings_layout.addWidget(self.bubble_gradient_start_button, 5, 1)
+        bubble_settings_layout.addWidget(gradient_end_label, 6, 0)
+        bubble_settings_layout.addWidget(self.bubble_gradient_end_button, 6, 1)
+        bubble_settings_layout.addWidget(gradient_angle_label, 7, 0)
+        bubble_settings_layout.addWidget(self.bubble_gradient_angle_spin, 7, 1)
+        bubble_settings_layout.addWidget(self.bubble_gradient_angle_slider, 7, 2)
 
         rendering_divider_top = MDivider()
         rendering_divider_bottom = MDivider()

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -319,6 +319,15 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
         self.hbutton_group.set_button_list(button_config_list)
         self.hbutton_group.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
 
+        self.bubble_mode_combo = MComboBox().small()
+        self.bubble_mode_combo.setToolTip(self.tr("Bubble Mode"))
+        self.bubble_mode_combo.addItem(self.tr("Auto"), "auto")
+        self.bubble_mode_combo.addItem(self.tr("Plain"), "plain")
+        self.bubble_mode_combo.addItem(self.tr("Translucent"), "translucent")
+        self.bubble_mode_combo.setCurrentIndex(0)
+        self.bubble_mode_combo.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
+        self.bubble_mode_combo.setFixedWidth(130)
+
         # Add progress bar
         self.progress_bar = MProgressBar().auto_color()
         self.progress_bar.setValue(0)
@@ -352,6 +361,7 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
 
         header_layout.addWidget(self.undo_tool_group)
         header_layout.addWidget(self.hbutton_group)
+        header_layout.addWidget(self.bubble_mode_combo)
         header_layout.addWidget(self.loading)
         header_layout.addStretch()
         header_layout.addWidget(self.webtoon_toggle)

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -534,6 +534,7 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
             'bubble_min_alpha': 110,
             'bubble_max_alpha': 205,
             'bubble_plain_alpha': 230,
+            'bubble_text_alpha': 255,
         })
 
         bubble_settings_layout = QtWidgets.QGridLayout()
@@ -577,10 +578,20 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
         self.bubble_plain_alpha_slider.setValue(self.bubble_plain_alpha_spin.value())
         self.bubble_plain_alpha_slider.setToolTip(self.tr('Plain bubble opacity'))
 
+        text_alpha_value = int(bubble_cfg.get('bubble_text_alpha', 255))
         gradient_enabled = bool(bubble_cfg.get('bubble_gradient_enabled', False))
         gradient_start_rgb = tuple(int(v) for v in bubble_cfg.get('bubble_gradient_start', bubble_rgb))
         gradient_end_rgb = tuple(int(v) for v in bubble_cfg.get('bubble_gradient_end', gradient_start_rgb))
         gradient_angle = int(float(bubble_cfg.get('bubble_gradient_angle', 90.0)))
+
+        text_alpha_label = QtWidgets.QLabel(self.tr('Text Alpha'))
+        self.bubble_text_alpha_spin = MSpinBox().small()
+        self.bubble_text_alpha_spin.setRange(0, 255)
+        self.bubble_text_alpha_spin.setValue(text_alpha_value)
+        self.bubble_text_alpha_slider = MSlider()
+        self.bubble_text_alpha_slider.setRange(0, 255)
+        self.bubble_text_alpha_slider.setValue(text_alpha_value)
+        self.bubble_text_alpha_slider.setToolTip(self.tr('Text opacity'))
 
         self.bubble_gradient_checkbox = MCheckBox(self.tr('Gradient Fill'))
         self.bubble_gradient_checkbox.setChecked(gradient_enabled)
@@ -631,14 +642,17 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
         bubble_settings_layout.addWidget(bubble_plain_alpha_label, 3, 0)
         bubble_settings_layout.addWidget(self.bubble_plain_alpha_spin, 3, 1)
         bubble_settings_layout.addWidget(self.bubble_plain_alpha_slider, 3, 2)
-        bubble_settings_layout.addWidget(self.bubble_gradient_checkbox, 4, 0, 1, 3)
-        bubble_settings_layout.addWidget(gradient_start_label, 5, 0)
-        bubble_settings_layout.addWidget(self.bubble_gradient_start_button, 5, 1)
-        bubble_settings_layout.addWidget(gradient_end_label, 6, 0)
-        bubble_settings_layout.addWidget(self.bubble_gradient_end_button, 6, 1)
-        bubble_settings_layout.addWidget(gradient_angle_label, 7, 0)
-        bubble_settings_layout.addWidget(self.bubble_gradient_angle_spin, 7, 1)
-        bubble_settings_layout.addWidget(self.bubble_gradient_angle_slider, 7, 2)
+        bubble_settings_layout.addWidget(text_alpha_label, 4, 0)
+        bubble_settings_layout.addWidget(self.bubble_text_alpha_spin, 4, 1)
+        bubble_settings_layout.addWidget(self.bubble_text_alpha_slider, 4, 2)
+        bubble_settings_layout.addWidget(self.bubble_gradient_checkbox, 5, 0, 1, 3)
+        bubble_settings_layout.addWidget(gradient_start_label, 6, 0)
+        bubble_settings_layout.addWidget(self.bubble_gradient_start_button, 6, 1)
+        bubble_settings_layout.addWidget(gradient_end_label, 7, 0)
+        bubble_settings_layout.addWidget(self.bubble_gradient_end_button, 7, 1)
+        bubble_settings_layout.addWidget(gradient_angle_label, 8, 0)
+        bubble_settings_layout.addWidget(self.bubble_gradient_angle_spin, 8, 1)
+        bubble_settings_layout.addWidget(self.bubble_gradient_angle_slider, 8, 2)
 
         rendering_divider_top = MDivider()
         rendering_divider_bottom = MDivider()

--- a/controller.py
+++ b/controller.py
@@ -215,6 +215,17 @@ class ComicTranslate(ComicTranslateUI):
         self.outline_width_dropdown.currentTextChanged.connect(self.text_ctrl.on_outline_width_change)
         self.outline_checkbox.stateChanged.connect(self.text_ctrl.toggle_outline_settings)
 
+        if getattr(self, 'bubble_mode_combo', None):
+            self.bubble_mode_combo.currentIndexChanged.connect(self.text_ctrl.on_bubble_mode_changed)
+        if getattr(self, 'bubble_color_button', None):
+            self.bubble_color_button.clicked.connect(self.text_ctrl.on_bubble_color_change)
+        if getattr(self, 'bubble_min_alpha_spin', None):
+            self.bubble_min_alpha_spin.valueChanged.connect(self.text_ctrl.on_bubble_min_alpha_change)
+        if getattr(self, 'bubble_max_alpha_spin', None):
+            self.bubble_max_alpha_spin.valueChanged.connect(self.text_ctrl.on_bubble_max_alpha_change)
+        if getattr(self, 'bubble_plain_alpha_spin', None):
+            self.bubble_plain_alpha_spin.valueChanged.connect(self.text_ctrl.on_bubble_plain_alpha_change)
+
         # Page List
         self.page_list.currentItemChanged.connect(self.image_ctrl.on_card_selected)
         self.page_list.selection_changed.connect(self.image_ctrl.on_selection_changed)

--- a/controller.py
+++ b/controller.py
@@ -101,6 +101,7 @@ class ComicTranslate(ComicTranslateUI):
             'bubble_flat_var': 8e-4,
             'bubble_plain_alpha': 230,
             'text_target_contrast': 4.5,
+            'bubble_text_alpha': 255,
             'bubble_gradient_enabled': False,
             'bubble_gradient_start': (35, 100, 160),
             'bubble_gradient_end': (200, 220, 255),
@@ -236,6 +237,14 @@ class ComicTranslate(ComicTranslateUI):
             self.bubble_plain_alpha_spin.valueChanged.connect(self.text_ctrl.on_bubble_plain_alpha_change)
         if getattr(self, 'bubble_plain_alpha_slider', None):
             self.bubble_plain_alpha_slider.valueChanged.connect(self.text_ctrl.on_bubble_plain_alpha_change)
+        if getattr(self, 'bubble_text_alpha_spin', None):
+            self.bubble_text_alpha_spin.valueChanged.connect(
+                partial(self.text_ctrl.on_bubble_text_alpha_change, source='spin')
+            )
+        if getattr(self, 'bubble_text_alpha_slider', None):
+            self.bubble_text_alpha_slider.valueChanged.connect(
+                partial(self.text_ctrl.on_bubble_text_alpha_change, source='slider')
+            )
         if getattr(self, 'bubble_gradient_checkbox', None):
             self.bubble_gradient_checkbox.stateChanged.connect(self.text_ctrl.on_bubble_gradient_toggled)
         if getattr(self, 'bubble_gradient_start_button', None):

--- a/controller.py
+++ b/controller.py
@@ -90,6 +90,18 @@ class ComicTranslate(ComicTranslateUI):
         self.text_ctrl = TextController(self)
         self.webtoon_ctrl = WebtoonController(self)
 
+        self.bubble_style_config = {
+            'bubble_mode': 'auto',
+            'bubble_rgb': (35, 100, 160),
+            'bubble_min_alpha': 110,
+            'bubble_max_alpha': 205,
+            'bubble_plain_hi': 0.88,
+            'bubble_plain_lo': 0.12,
+            'bubble_flat_var': 8e-4,
+            'bubble_plain_alpha': 230,
+            'text_target_contrast': 4.5,
+        }
+
         self.image_skipped.connect(self.image_ctrl.on_image_skipped)
         self.image_processed.connect(self.image_ctrl.on_image_processed)
         self.patches_processed.connect(self.image_ctrl.on_inpaint_patches_processed)

--- a/controller.py
+++ b/controller.py
@@ -92,20 +92,21 @@ class ComicTranslate(ComicTranslateUI):
         self.webtoon_ctrl = WebtoonController(self)
 
         self.bubble_style_config = {
-            'bubble_mode': 'auto',
-            'bubble_rgb': (35, 100, 160),
-            'bubble_min_alpha': 110,
-            'bubble_max_alpha': 205,
-            'bubble_plain_hi': 0.88,
-            'bubble_plain_lo': 0.12,
-            'bubble_flat_var': 8e-4,
-            'bubble_plain_alpha': 230,
+            'text_color_mode': 'auto',
+            'custom_text_rgb': (0, 0, 0),
+            'text_fill_opacity': 1.0,
+            'stroke_enabled': False,
+            'stroke_width': 2.0,
+            'stroke_opacity': 1.0,
+            'auto_contrast': True,
             'text_target_contrast': 4.5,
-            'bubble_text_alpha': 255,
-            'bubble_gradient_enabled': False,
-            'bubble_gradient_start': (35, 100, 160),
-            'bubble_gradient_end': (200, 220, 255),
-            'bubble_gradient_angle': 90.0,
+            'background_box_mode': 'off',
+            'background_box_opacity': 0.25,
+            'bubble_rgb': (35, 100, 160),
+            'background_plain_hi': 0.95,
+            'background_plain_lo': 0.05,
+            'flat_variance_threshold': 4e-4,
+            'auto_stroke_opacity': 0.6,
         }
 
         self.image_skipped.connect(self.image_ctrl.on_image_skipped)
@@ -221,43 +222,45 @@ class ComicTranslate(ComicTranslateUI):
         self.outline_width_dropdown.currentTextChanged.connect(self.text_ctrl.on_outline_width_change)
         self.outline_checkbox.stateChanged.connect(self.text_ctrl.toggle_outline_settings)
 
-        if getattr(self, 'bubble_mode_combo', None):
-            self.bubble_mode_combo.currentIndexChanged.connect(self.text_ctrl.on_bubble_mode_changed)
         if getattr(self, 'bubble_color_button', None):
             self.bubble_color_button.clicked.connect(self.text_ctrl.on_bubble_color_change)
-        if getattr(self, 'bubble_min_alpha_spin', None):
-            self.bubble_min_alpha_spin.valueChanged.connect(self.text_ctrl.on_bubble_min_alpha_change)
-        if getattr(self, 'bubble_min_alpha_slider', None):
-            self.bubble_min_alpha_slider.valueChanged.connect(self.text_ctrl.on_bubble_min_alpha_change)
-        if getattr(self, 'bubble_max_alpha_spin', None):
-            self.bubble_max_alpha_spin.valueChanged.connect(self.text_ctrl.on_bubble_max_alpha_change)
-        if getattr(self, 'bubble_max_alpha_slider', None):
-            self.bubble_max_alpha_slider.valueChanged.connect(self.text_ctrl.on_bubble_max_alpha_change)
-        if getattr(self, 'bubble_plain_alpha_spin', None):
-            self.bubble_plain_alpha_spin.valueChanged.connect(self.text_ctrl.on_bubble_plain_alpha_change)
-        if getattr(self, 'bubble_plain_alpha_slider', None):
-            self.bubble_plain_alpha_slider.valueChanged.connect(self.text_ctrl.on_bubble_plain_alpha_change)
-        if getattr(self, 'bubble_text_alpha_spin', None):
-            self.bubble_text_alpha_spin.valueChanged.connect(
-                partial(self.text_ctrl.on_bubble_text_alpha_change, source='spin')
+        if getattr(self, 'text_color_mode_combo', None):
+            self.text_color_mode_combo.currentIndexChanged.connect(self.text_ctrl.on_text_color_mode_change)
+        if getattr(self, 'custom_text_color_button', None):
+            self.custom_text_color_button.clicked.connect(self.text_ctrl.on_custom_text_color_change)
+        if getattr(self, 'text_opacity_spin', None):
+            self.text_opacity_spin.valueChanged.connect(
+                partial(self.text_ctrl.on_text_opacity_change, source='spin')
             )
-        if getattr(self, 'bubble_text_alpha_slider', None):
-            self.bubble_text_alpha_slider.valueChanged.connect(
-                partial(self.text_ctrl.on_bubble_text_alpha_change, source='slider')
+        if getattr(self, 'text_opacity_slider', None):
+            self.text_opacity_slider.valueChanged.connect(
+                partial(self.text_ctrl.on_text_opacity_change, source='slider')
             )
-        if getattr(self, 'bubble_gradient_checkbox', None):
-            self.bubble_gradient_checkbox.stateChanged.connect(self.text_ctrl.on_bubble_gradient_toggled)
-        if getattr(self, 'bubble_gradient_start_button', None):
-            self.bubble_gradient_start_button.clicked.connect(self.text_ctrl.on_bubble_gradient_start_change)
-        if getattr(self, 'bubble_gradient_end_button', None):
-            self.bubble_gradient_end_button.clicked.connect(self.text_ctrl.on_bubble_gradient_end_change)
-        if getattr(self, 'bubble_gradient_angle_spin', None):
-            self.bubble_gradient_angle_spin.valueChanged.connect(
-                partial(self.text_ctrl.on_bubble_gradient_angle_change, source='spin')
+        if getattr(self, 'stroke_checkbox', None):
+            self.stroke_checkbox.stateChanged.connect(self.text_ctrl.on_stroke_toggled)
+        if getattr(self, 'stroke_width_spin', None):
+            self.stroke_width_spin.valueChanged.connect(self.text_ctrl.on_stroke_width_change)
+        if getattr(self, 'stroke_opacity_spin', None):
+            self.stroke_opacity_spin.valueChanged.connect(
+                partial(self.text_ctrl.on_stroke_opacity_change, source='spin')
             )
-        if getattr(self, 'bubble_gradient_angle_slider', None):
-            self.bubble_gradient_angle_slider.valueChanged.connect(
-                partial(self.text_ctrl.on_bubble_gradient_angle_change, source='slider')
+        if getattr(self, 'stroke_opacity_slider', None):
+            self.stroke_opacity_slider.valueChanged.connect(
+                partial(self.text_ctrl.on_stroke_opacity_change, source='slider')
+            )
+        if getattr(self, 'auto_contrast_checkbox', None):
+            self.auto_contrast_checkbox.stateChanged.connect(self.text_ctrl.on_auto_contrast_toggled)
+        if getattr(self, 'background_box_mode_combo', None):
+            self.background_box_mode_combo.currentIndexChanged.connect(
+                self.text_ctrl.on_background_box_mode_change
+            )
+        if getattr(self, 'background_box_opacity_spin', None):
+            self.background_box_opacity_spin.valueChanged.connect(
+                partial(self.text_ctrl.on_background_box_opacity_change, source='spin')
+            )
+        if getattr(self, 'background_box_opacity_slider', None):
+            self.background_box_opacity_slider.valueChanged.connect(
+                partial(self.text_ctrl.on_background_box_opacity_change, source='slider')
             )
 
         # Page List

--- a/controller.py
+++ b/controller.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 import shutil
 import tempfile
+from functools import partial
 from typing import Callable, Tuple
 
 from PySide6 import QtCore
@@ -100,6 +101,10 @@ class ComicTranslate(ComicTranslateUI):
             'bubble_flat_var': 8e-4,
             'bubble_plain_alpha': 230,
             'text_target_contrast': 4.5,
+            'bubble_gradient_enabled': False,
+            'bubble_gradient_start': (35, 100, 160),
+            'bubble_gradient_end': (200, 220, 255),
+            'bubble_gradient_angle': 90.0,
         }
 
         self.image_skipped.connect(self.image_ctrl.on_image_skipped)
@@ -221,10 +226,30 @@ class ComicTranslate(ComicTranslateUI):
             self.bubble_color_button.clicked.connect(self.text_ctrl.on_bubble_color_change)
         if getattr(self, 'bubble_min_alpha_spin', None):
             self.bubble_min_alpha_spin.valueChanged.connect(self.text_ctrl.on_bubble_min_alpha_change)
+        if getattr(self, 'bubble_min_alpha_slider', None):
+            self.bubble_min_alpha_slider.valueChanged.connect(self.text_ctrl.on_bubble_min_alpha_change)
         if getattr(self, 'bubble_max_alpha_spin', None):
             self.bubble_max_alpha_spin.valueChanged.connect(self.text_ctrl.on_bubble_max_alpha_change)
+        if getattr(self, 'bubble_max_alpha_slider', None):
+            self.bubble_max_alpha_slider.valueChanged.connect(self.text_ctrl.on_bubble_max_alpha_change)
         if getattr(self, 'bubble_plain_alpha_spin', None):
             self.bubble_plain_alpha_spin.valueChanged.connect(self.text_ctrl.on_bubble_plain_alpha_change)
+        if getattr(self, 'bubble_plain_alpha_slider', None):
+            self.bubble_plain_alpha_slider.valueChanged.connect(self.text_ctrl.on_bubble_plain_alpha_change)
+        if getattr(self, 'bubble_gradient_checkbox', None):
+            self.bubble_gradient_checkbox.stateChanged.connect(self.text_ctrl.on_bubble_gradient_toggled)
+        if getattr(self, 'bubble_gradient_start_button', None):
+            self.bubble_gradient_start_button.clicked.connect(self.text_ctrl.on_bubble_gradient_start_change)
+        if getattr(self, 'bubble_gradient_end_button', None):
+            self.bubble_gradient_end_button.clicked.connect(self.text_ctrl.on_bubble_gradient_end_change)
+        if getattr(self, 'bubble_gradient_angle_spin', None):
+            self.bubble_gradient_angle_spin.valueChanged.connect(
+                partial(self.text_ctrl.on_bubble_gradient_angle_change, source='spin')
+            )
+        if getattr(self, 'bubble_gradient_angle_slider', None):
+            self.bubble_gradient_angle_slider.valueChanged.connect(
+                partial(self.text_ctrl.on_bubble_gradient_angle_change, source='slider')
+            )
 
         # Page List
         self.page_list.currentItemChanged.connect(self.image_ctrl.on_card_selected)

--- a/modules/rendering/dynamic_bubble.py
+++ b/modules/rendering/dynamic_bubble.py
@@ -176,6 +176,40 @@ def _normalise_ratio_value(value: float) -> float:
     return float(np.clip(value, 0.0, 1.0))
 
 
+def image_overlaps_any_block(
+    image: Optional[np.ndarray], blocks: Iterable[TextBlock]
+) -> bool:
+    """Return True if the image intersects at least one block."""
+
+    if image is None or getattr(image, "size", 0) == 0:
+        return False
+
+    height, width = image.shape[:2]
+    for blk in blocks:
+        coords = getattr(blk, "xyxy", None)
+        if coords is None:
+            continue
+
+        try:
+            arr = np.asarray(coords, dtype=np.float32).reshape(-1)
+        except Exception:
+            continue
+
+        if arr.size < 4:
+            continue
+
+        x0, y0, x1, y1 = (float(arr[i]) for i in range(4))
+
+        if x1 <= 0 or y1 <= 0:
+            continue
+        if x0 >= width or y0 >= height:
+            continue
+
+        return True
+
+    return False
+
+
 def compute_dynamic_bubble_style(
     image: np.ndarray,
     blk: TextBlock,
@@ -392,4 +426,8 @@ def compute_dynamic_bubble_style(
     )
 
 
-__all__ = ["BubbleRenderStyle", "compute_dynamic_bubble_style"]
+__all__ = [
+    "BubbleRenderStyle",
+    "compute_dynamic_bubble_style",
+    "image_overlaps_any_block",
+]

--- a/modules/rendering/dynamic_bubble.py
+++ b/modules/rendering/dynamic_bubble.py
@@ -1,0 +1,283 @@
+"""Dynamic speech bubble styling utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence, Tuple
+
+import numpy as np
+
+from ..utils.textblock import TextBlock
+
+RgbTuple = Tuple[int, int, int]
+RgbaTuple = Tuple[int, int, int, int]
+
+
+@dataclass
+class BubbleRenderStyle:
+    """Container describing how to draw a translated speech bubble."""
+
+    fill_rgba: RgbaTuple
+    text_rgb: RgbTuple
+    outline_rgb: RgbTuple
+    outline_width: float
+    shadow_rgba: Optional[RgbaTuple]
+    shadow_offset: Tuple[float, float]
+    padding: Tuple[float, float, float, float]
+    corner_radius: float
+    reason: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "fill_rgba": tuple(self.fill_rgba),
+            "text_rgb": tuple(self.text_rgb),
+            "outline_rgb": tuple(self.outline_rgb),
+            "outline_width": float(self.outline_width),
+            "shadow_rgba": tuple(self.shadow_rgba) if self.shadow_rgba else None,
+            "shadow_offset": tuple(self.shadow_offset),
+            "padding": tuple(self.padding),
+            "corner_radius": float(self.corner_radius),
+            "reason": self.reason,
+        }
+
+
+def _ensure_bbox_within_image(
+    image: np.ndarray, bbox: Sequence[float]
+) -> Optional[Tuple[int, int, int, int]]:
+    if image is None or bbox is None:
+        return None
+
+    height, width = image.shape[:2]
+    x0, y0, x1, y1 = bbox
+    x0 = int(np.clip(np.floor(x0), 0, width))
+    y0 = int(np.clip(np.floor(y0), 0, height))
+    x1 = int(np.clip(np.ceil(x1), x0 + 1, width))
+    y1 = int(np.clip(np.ceil(y1), y0 + 1, height))
+
+    if x1 <= x0 or y1 <= y0:
+        return None
+    return x0, y0, x1, y1
+
+
+def _srgb_to_linear(values: np.ndarray) -> np.ndarray:
+    values = np.asarray(values, dtype=np.float32) / 255.0
+    return np.where(values <= 0.04045, values / 12.92, ((values + 0.055) / 1.055) ** 2.4)
+
+
+def _relative_luminance(rgb: np.ndarray | Iterable[float]) -> float:
+    arr = np.asarray(rgb, dtype=np.float32)
+    if arr.ndim and arr.shape[-1] == 3:
+        r, g, b = arr[..., 0], arr[..., 1], arr[..., 2]
+    else:
+        r, g, b = arr
+    return float(0.2126 * r + 0.7152 * g + 0.0722 * b)
+
+
+def _relative_luminance_srgb(rgb: np.ndarray) -> np.ndarray:
+    linear = _srgb_to_linear(rgb)
+    return (
+        0.2126 * linear[..., 0]
+        + 0.7152 * linear[..., 1]
+        + 0.0722 * linear[..., 2]
+    )
+
+
+def _mean_variance_patch(image: np.ndarray, bbox: Tuple[int, int, int, int]):
+    x0, y0, x1, y1 = bbox
+    patch = image[y0:y1, x0:x1]
+    if patch.size == 0:
+        return (np.array([127.0, 127.0, 127.0], dtype=np.float32), 0.5, 0.0)
+
+    patch_float = patch.astype(np.float32)
+    mean_rgb = patch_float.reshape(-1, patch.shape[-1]).mean(axis=0)
+    luminance = _relative_luminance_srgb(patch_float)
+    mean_lum = float(luminance.mean()) if luminance.size else 0.5
+    variance = float(luminance.var()) if luminance.size else 0.0
+    return mean_rgb, mean_lum, variance
+
+
+def _blend_over(bg_rgb: np.ndarray, fg_rgba: Sequence[int]) -> np.ndarray:
+    bg_rgb = np.asarray(bg_rgb, dtype=np.float32)
+    fr, fg, fb, fa = fg_rgba
+    alpha = fa / 255.0
+    blended = np.array(
+        [
+            fr * alpha + bg_rgb[0] * (1.0 - alpha),
+            fg * alpha + bg_rgb[1] * (1.0 - alpha),
+            fb * alpha + bg_rgb[2] * (1.0 - alpha),
+        ],
+        dtype=np.float32,
+    )
+    return blended
+
+
+def _contrast_ratio(l1: float, l2: float) -> float:
+    bright, dark = max(l1, l2), min(l1, l2)
+    return (bright + 0.05) / (dark + 0.05)
+
+
+def _clip_rgb(rgb: np.ndarray | Sequence[float]) -> np.ndarray:
+    arr = np.asarray(rgb, dtype=np.float32)
+    arr = np.clip(arr, 0.0, 255.0)
+    return arr
+
+
+def _as_int_tuple(values: np.ndarray | Sequence[float]) -> Tuple[int, int, int]:
+    arr = _clip_rgb(values)
+    return tuple(int(round(float(v))) for v in arr[:3])
+
+
+def _normalise_padding(padding: Sequence[float] | float, scale: float) -> Tuple[float, float, float, float]:
+    if isinstance(padding, (int, float)):
+        value = float(padding) * scale
+        return value, value, value, value
+    if len(padding) == 2:
+        px, py = padding
+        return float(px) * scale, float(py) * scale, float(px) * scale, float(py) * scale
+    if len(padding) == 4:
+        left, top, right, bottom = padding
+        return (
+            float(left) * scale,
+            float(top) * scale,
+            float(right) * scale,
+            float(bottom) * scale,
+        )
+    value = float(padding[0]) if padding else 12.0
+    value *= scale
+    return value, value, value, value
+
+
+def _pick_text_color_for_bubble(
+    image: np.ndarray,
+    bbox: Tuple[int, int, int, int],
+    bubble_rgb: Optional[Sequence[int]],
+    bubble_alpha: int,
+    plain_thresh_hi: float = 0.88,
+    plain_thresh_lo: float = 0.12,
+    flat_var: float = 8e-4,
+) -> Tuple[Optional[RgbTuple], str]:
+    """Return a forced text colour for plain bubbles/backgrounds."""
+
+    mean_rgb, mean_lum, variance = _mean_variance_patch(image, bbox)
+
+    if bubble_rgb is not None and bubble_alpha >= 210:
+        bubble_lum = _relative_luminance(_srgb_to_linear(np.asarray(bubble_rgb)))
+        if bubble_lum >= plain_thresh_hi:
+            return (0, 0, 0), "plain_white_bubble"
+        if bubble_lum <= plain_thresh_lo:
+            return (255, 255, 255), "plain_black_bubble"
+        return ((0, 0, 0) if bubble_lum > 0.5 else (255, 255, 255)), "opaque_mid_bubble"
+
+    if variance < flat_var:
+        if mean_lum >= plain_thresh_hi:
+            return (0, 0, 0), "plain_white_bg"
+        if mean_lum <= plain_thresh_lo:
+            return (255, 255, 255), "plain_black_bg"
+
+    return None, "use_adaptive"
+
+
+def compute_dynamic_bubble_style(
+    image: np.ndarray,
+    blk: TextBlock,
+    bubble_rgb: Sequence[int] = (35, 100, 160),
+    min_alpha: int = 110,
+    max_alpha: int = 205,
+    corner_radius_factor: float = 0.18,
+    padding: Sequence[float] | float = (12.0, 8.0),
+    text_min_contrast: float = 4.5,
+    max_variance_reference: float = 0.04,
+) -> Optional[BubbleRenderStyle]:
+    """Compute a dynamic bubble style for a translated text block."""
+
+    if image is None or blk is None:
+        return None
+
+    bbox_source = getattr(blk, "bubble_xyxy", None) or getattr(blk, "xyxy", None)
+    if bbox_source is None:
+        return None
+
+    bbox = _ensure_bbox_within_image(image, bbox_source)
+    if bbox is None:
+        return None
+
+    mean_rgb, mean_lum, variance = _mean_variance_patch(image, bbox)
+
+    var_clamped = float(np.clip(variance, 0.0, max_variance_reference))
+    t = var_clamped / max_variance_reference if max_variance_reference > 0 else 1.0
+    alpha = int(round(min_alpha + (max_alpha - min_alpha) * t))
+    alpha = int(np.clip(alpha, min_alpha, max_alpha))
+
+    base_rgb = np.asarray(bubble_rgb, dtype=np.float32)
+    mean_rgb = np.asarray(mean_rgb, dtype=np.float32)
+
+    adjust = np.array([20.0 if mean_rgb[0] > base_rgb[0] else -20.0, 0.0, 0.0], dtype=np.float32)
+    adjust[1] = 12.0 if mean_rgb[1] < base_rgb[1] else -12.0
+    adjusted_rgb = _clip_rgb(base_rgb + adjust)
+    adjusted_rgb_tuple = _as_int_tuple(adjusted_rgb)
+
+    forced_color, reason = _pick_text_color_for_bubble(image, bbox, adjusted_rgb_tuple, alpha)
+
+    fill_rgba = (*adjusted_rgb_tuple, alpha)
+    blended_rgb = _blend_over(mean_rgb, fill_rgba)
+    blended_lum = _relative_luminance(_srgb_to_linear(blended_rgb))
+
+    if forced_color is not None:
+        text_rgb = forced_color
+    else:
+        candidates = [
+            np.array([255.0, 255.0, 255.0], dtype=np.float32),
+            np.array([0.0, 0.0, 0.0], dtype=np.float32),
+            255.0 - blended_rgb,
+        ]
+        best_rgb = candidates[0]
+        best_ratio = -1.0
+        for cand in candidates:
+            cand_lum = _relative_luminance(_srgb_to_linear(cand))
+            ratio = _contrast_ratio(blended_lum, cand_lum)
+            if ratio > best_ratio:
+                best_ratio = ratio
+                best_rgb = cand
+            if ratio >= text_min_contrast:
+                best_rgb = cand
+                best_ratio = ratio
+                break
+        text_rgb = _as_int_tuple(best_rgb)
+        if best_ratio < text_min_contrast:
+            reason = f"low_contrast_{best_ratio:.2f}"
+
+    text_linear = _relative_luminance(_srgb_to_linear(np.array(text_rgb, dtype=np.float32)))
+    outline_target = (0, 0, 0) if text_linear > blended_lum else (255, 255, 255)
+    outline_rgb = outline_target
+
+    outline_width = 2.0 if alpha >= 150 else 3.0
+
+    shadow_alpha = 120 if text_linear >= blended_lum else 90
+    shadow_rgb = (0, 0, 0) if text_linear >= blended_lum else (255, 255, 255)
+    shadow_rgba = (*shadow_rgb, shadow_alpha)
+    shadow_offset = (0.0, 1.0)
+
+    x0, y0, x1, y1 = bbox
+    width = float(x1 - x0)
+    height = float(y1 - y0)
+    scale = max(1.0, 0.08 * np.sqrt(width * height) / 50.0)
+    pad_l, pad_t, pad_r, pad_b = _normalise_padding(padding, scale)
+    corner_radius = max(6.0, min(width, height) * corner_radius_factor)
+
+    return BubbleRenderStyle(
+        fill_rgba=fill_rgba,
+        text_rgb=text_rgb,
+        outline_rgb=outline_rgb,
+        outline_width=outline_width,
+        shadow_rgba=shadow_rgba,
+        shadow_offset=shadow_offset,
+        padding=(pad_l, pad_t, pad_r, pad_b),
+        corner_radius=corner_radius,
+        reason=reason,
+    )
+
+
+__all__ = [
+    "BubbleRenderStyle",
+    "compute_dynamic_bubble_style",
+]

--- a/modules/rendering/dynamic_bubble.py
+++ b/modules/rendering/dynamic_bubble.py
@@ -88,11 +88,21 @@ def _relative_luminance(rgb: np.ndarray | Iterable[float]) -> float:
     return float(0.2126 * r + 0.7152 * g + 0.0722 * b)
 
 
-def _mean_variance_patch(image: np.ndarray, bbox: Tuple[int, int, int, int]):
+def _mean_variance_patch(
+    image: np.ndarray, bbox: Tuple[int, int, int, int], sample_limit: int = 16
+):
     x0, y0, x1, y1 = bbox
     patch = image[y0:y1, x0:x1]
     if patch.size == 0:
         return (np.array([127.0, 127.0, 127.0], dtype=np.float32), 0.5, 0.0)
+
+    if patch.ndim == 2:
+        patch = np.expand_dims(patch, axis=-1)
+
+    if sample_limit > 0:
+        step_y = max(1, patch.shape[0] // sample_limit)
+        step_x = max(1, patch.shape[1] // sample_limit)
+        patch = patch[::step_y, ::step_x]
 
     patch_float = patch.astype(np.float32)
     mean_rgb = patch_float.reshape(-1, patch.shape[-1]).mean(axis=0)
@@ -210,6 +220,8 @@ def compute_dynamic_bubble_style(
     reason = "auto"
     plain_background: Optional[str] = None
     auto_stroke_required = False
+    auto_shadow_required = False
+    stroke_source = "user" if stroke_enabled else "none"
 
     def _to_rgb_tuple(candidate: Optional[Sequence[int]], fallback: Tuple[int, int, int]) -> Tuple[int, int, int]:
         if candidate is None:
@@ -218,6 +230,13 @@ def compute_dynamic_bubble_style(
         if arr.size < 3:
             return fallback
         return _as_int_tuple(arr[:3])
+
+    def _contrast_for_rgb(rgb: Tuple[int, int, int]) -> float:
+        lum = _relative_luminance(_srgb_to_linear(np.array(rgb, dtype=np.float32)))
+        return _contrast_ratio(mean_lum, lum)
+
+    is_plain_white = auto_contrast and mean_lum >= background_plain_hi and lum_std <= flat_std_threshold
+    is_plain_black = auto_contrast and mean_lum <= background_plain_lo and lum_std <= flat_std_threshold
 
     if mode == "black":
         text_rgb = (0, 0, 0)
@@ -229,43 +248,39 @@ def compute_dynamic_bubble_style(
         text_rgb = _to_rgb_tuple(custom_text_rgb, (0, 0, 0))
         reason = "user_custom"
     else:
-        is_plain_white = mean_lum >= background_plain_hi and lum_std <= flat_std_threshold
-        is_plain_black = mean_lum <= background_plain_lo and lum_std <= flat_std_threshold
-
-        if auto_contrast and is_plain_white:
+        if is_plain_white:
             text_rgb = (0, 0, 0)
             reason = "plain_white_bg"
             plain_background = "white"
-        elif auto_contrast and is_plain_black:
+        elif is_plain_black:
             text_rgb = (255, 255, 255)
             reason = "plain_black_bg"
             plain_background = "black"
         elif auto_contrast:
-            candidates = [((0, 0, 0), "black"), ((255, 255, 255), "white")]
-            best_ratio = -1.0
             best_color = (0, 0, 0)
             best_label = "black"
-            for cand_rgb, label in candidates:
-                cand_lum = _relative_luminance(
-                    _srgb_to_linear(np.array(cand_rgb, dtype=np.float32))
-                )
-                ratio = _contrast_ratio(mean_lum, cand_lum)
-                if ratio > best_ratio:
-                    best_ratio = ratio
+            best_ratio = -1.0
+            met_target = False
+            for cand_rgb, label in (((0, 0, 0), "black"), ((255, 255, 255), "white")):
+                ratio = _contrast_for_rgb(cand_rgb)
+                if ratio >= text_min_contrast and not met_target:
                     best_color = cand_rgb
                     best_label = label
-                if ratio >= text_min_contrast:
-                    best_color = cand_rgb
                     best_ratio = ratio
-                    best_label = label
+                    met_target = True
                     break
+                if ratio > best_ratio:
+                    best_color = cand_rgb
+                    best_label = label
+                    best_ratio = ratio
 
             text_rgb = best_color
             if best_ratio >= text_min_contrast:
-                reason = f"dynamic_{best_label}"
+                reason = f"dynamic_{best_label}_{best_ratio:.2f}"
             else:
-                reason = f"dynamic_low_contrast_{best_ratio:.2f}"
+                reason = f"dynamic_needs_outline_{best_ratio:.2f}"
                 auto_stroke_required = True
+                auto_shadow_required = True
         else:
             text_rgb = (0, 0, 0)
             reason = "auto_contrast_disabled"
@@ -273,39 +288,57 @@ def compute_dynamic_bubble_style(
     text_opacity = _normalise_ratio_value(text_opacity)
     text_alpha_value = int(np.clip(round(text_opacity * 255.0), 0, 255))
 
-    stroke_color = (255, 255, 255) if text_rgb == (0, 0, 0) else (0, 0, 0)
-    stroke_active = bool(stroke_enabled)
-    if plain_background == "white":
-        stroke_color = (255, 255, 255)
-        stroke_active = stroke_active or auto_contrast
-    elif plain_background == "black":
-        stroke_color = (0, 0, 0)
-        stroke_active = stroke_active or auto_contrast
+    # For user-forced colours, honour the choice but still evaluate contrast if auto_contrast is enabled.
+    if mode in {"black", "white", "custom"} and auto_contrast:
+        ratio = _contrast_for_rgb(text_rgb)
+        if ratio < text_min_contrast:
+            auto_stroke_required = True
+            auto_shadow_required = True
+            reason = f"{reason}_needs_outline_{ratio:.2f}"
+        else:
+            reason = f"{reason}_{ratio:.2f}"
 
-    if auto_stroke_required:
+    text_lum = _relative_luminance(_srgb_to_linear(np.array(text_rgb, dtype=np.float32)))
+    stroke_color = (0, 0, 0) if text_lum >= 0.5 else (255, 255, 255)
+
+    stroke_active = bool(stroke_enabled)
+    if plain_background and auto_contrast:
         stroke_active = True
-        stroke_color = (255, 255, 255) if text_rgb == (0, 0, 0) else (0, 0, 0)
+        stroke_source = "plain"
+    elif auto_stroke_required:
+        stroke_active = True
+        stroke_source = "auto"
 
     stroke_opacity = _normalise_ratio_value(stroke_opacity)
     auto_stroke_opacity = _normalise_ratio_value(auto_stroke_opacity)
 
+    stroke_alpha_value = 0
+    outline_width_value = 0.0
+
     if stroke_active:
-        if auto_stroke_required or plain_background:
+        if stroke_source == "auto":
             base_opacity = auto_stroke_opacity
+            outline_width_value = max(float(stroke_width), 2.0)
+        elif stroke_source == "plain":
+            base_opacity = auto_stroke_opacity if not stroke_enabled else max(stroke_opacity, auto_stroke_opacity)
+            outline_width_value = max(float(stroke_width), 1.5)
         else:
             base_opacity = stroke_opacity
-        if plain_background and not auto_stroke_required:
-            base_opacity = min(base_opacity, auto_stroke_opacity)
-        stroke_alpha_value = int(np.clip(round(base_opacity * 255.0), 0, 255))
-    else:
-        stroke_alpha_value = 0
+            outline_width_value = float(stroke_width)
 
-    outline_width = float(stroke_width) if stroke_alpha_value > 0 else 0.0
+        stroke_alpha_value = int(np.clip(round(base_opacity * 255.0), 0, 255))
+        if stroke_alpha_value <= 0:
+            outline_width_value = 0.0
+        elif outline_width_value <= 0.0:
+            outline_width_value = 1.5 if stroke_source in {"auto", "plain"} else 1.0
+
+    shadow_rgba: Optional[RgbaTuple] = None
+    if auto_shadow_required and stroke_alpha_value > 0 and not plain_background:
+        shadow_alpha = int(np.clip(round(auto_stroke_opacity * 255.0 * 0.5), 0, 255))
+        if shadow_alpha > 0:
+            shadow_rgba = (stroke_color[0], stroke_color[1], stroke_color[2], shadow_alpha)
 
     bg_lum = _relative_luminance(_srgb_to_linear(mean_rgb))
-    text_lum = _relative_luminance(
-        _srgb_to_linear(np.array(text_rgb, dtype=np.float32))
-    )
     contrast_ratio = _contrast_ratio(bg_lum, text_lum)
 
     fill_rgba: RgbaTuple = (0, 0, 0, 0)
@@ -323,7 +356,6 @@ def compute_dynamic_bubble_style(
     if fill_rgba[3] <= 0:
         padding = (0.0, 0.0, 0.0, 0.0)
         corner_radius = 0.0
-        shadow_rgba = None
     else:
         x0, y0, x1, y1 = bbox
         width = float(x1 - x0)
@@ -334,13 +366,14 @@ def compute_dynamic_bubble_style(
         shadow_rgba = None
 
     logger.info(
-        "text_style mode=%s reason=%s variance=%.6f std=%.6f contrast=%.2f stroke=%s",
+        "text_style mode=%s reason=%s variance=%.6f std=%.6f contrast=%.2f stroke=%s source=%s",
         text_color_mode,
         reason,
         variance,
         lum_std,
         contrast_ratio,
         "on" if stroke_alpha_value > 0 else "off",
+        stroke_source,
     )
 
     return BubbleRenderStyle(
@@ -349,7 +382,7 @@ def compute_dynamic_bubble_style(
         text_alpha=text_alpha_value,
         outline_rgb=stroke_color,
         outline_alpha=stroke_alpha_value,
-        outline_width=outline_width,
+        outline_width=outline_width_value,
         shadow_rgba=shadow_rgba,
         shadow_offset=(0.0, 1.0),
         padding=padding,

--- a/modules/rendering/dynamic_bubble.py
+++ b/modules/rendering/dynamic_bubble.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Iterable, Optional, Sequence, Tuple
 
 import numpy as np
 
 from ..utils.textblock import TextBlock
+
+logger = logging.getLogger(__name__)
 
 RgbTuple = Tuple[int, int, int]
 RgbaTuple = Tuple[int, int, int, int]
@@ -147,34 +150,125 @@ def _normalise_padding(padding: Sequence[float] | float, scale: float) -> Tuple[
     return value, value, value, value
 
 
-def _pick_text_color_for_bubble(
-    image: np.ndarray,
-    bbox: Tuple[int, int, int, int],
-    bubble_rgb: Optional[Sequence[int]],
-    bubble_alpha: int,
-    plain_thresh_hi: float = 0.88,
-    plain_thresh_lo: float = 0.12,
-    flat_var: float = 8e-4,
-) -> Tuple[Optional[RgbTuple], str]:
-    """Return a forced text colour for plain bubbles/backgrounds."""
+def _select_text_rgb(
+    bubble_over_rgb: np.ndarray, text_min_contrast: float
+) -> Tuple[RgbTuple, float, str]:
+    """Pick a text colour with sufficient contrast against the blended bubble."""
 
-    mean_rgb, mean_lum, variance = _mean_variance_patch(image, bbox)
+    candidates = [
+        np.array([255.0, 255.0, 255.0], dtype=np.float32),
+        np.array([0.0, 0.0, 0.0], dtype=np.float32),
+        255.0 - bubble_over_rgb,
+    ]
+    best_rgb = candidates[0]
+    best_ratio = -1.0
+    result_reason = "dynamic"
+    bubble_lum = _relative_luminance(_srgb_to_linear(bubble_over_rgb))
 
-    if bubble_rgb is not None and bubble_alpha >= 210:
-        bubble_lum = _relative_luminance(_srgb_to_linear(np.asarray(bubble_rgb)))
+    for cand in candidates:
+        cand_lum = _relative_luminance(_srgb_to_linear(cand))
+        ratio = _contrast_ratio(bubble_lum, cand_lum)
+        if ratio > best_ratio:
+            best_ratio = ratio
+            best_rgb = cand
+        if ratio >= text_min_contrast:
+            best_rgb = cand
+            best_ratio = ratio
+            break
+
+    if best_ratio < text_min_contrast:
+        result_reason = f"dynamic_low_contrast_{best_ratio:.2f}"
+
+    return _as_int_tuple(best_rgb), best_ratio, result_reason
+
+
+def _choose_fill_and_text(
+    mean_rgb: np.ndarray,
+    mean_lum: float,
+    variance: float,
+    bubble_rgb: Sequence[int],
+    dynamic_alpha: int,
+    bubble_mode: str,
+    plain_alpha: int,
+    plain_thresh_hi: float,
+    plain_thresh_lo: float,
+    flat_var: float,
+    text_min_contrast: float,
+) -> Tuple[RgbaTuple, RgbTuple, float, str, np.ndarray]:
+    """Select bubble fill, text colour, and contrast telemetry."""
+
+    bubble_mode_normalised = (bubble_mode or "auto").lower()
+    enable_plain_shortcuts = bubble_mode_normalised == "auto"
+
+    bubble_rgb_arr = np.asarray(bubble_rgb, dtype=np.float32)
+    bubble_rgba_dynamic = (*_as_int_tuple(bubble_rgb_arr), int(dynamic_alpha))
+    bubble_lum = _relative_luminance(_srgb_to_linear(bubble_rgb_arr))
+
+    if bubble_mode_normalised == "plain":
+        fill_rgba = (*_as_int_tuple(bubble_rgb_arr), int(plain_alpha))
+        bubble_over = _blend_over(mean_rgb, fill_rgba)
+        text_rgb = (0, 0, 0) if bubble_lum >= 0.5 else (255, 255, 255)
+        text_lum = _relative_luminance(_srgb_to_linear(np.array(text_rgb, dtype=np.float32)))
+        bubble_lum_post = _relative_luminance(_srgb_to_linear(bubble_over))
+        contrast = _contrast_ratio(text_lum, bubble_lum_post)
+        return fill_rgba, text_rgb, contrast, "plain_mode", bubble_over
+
+    if enable_plain_shortcuts and dynamic_alpha >= 210:
         if bubble_lum >= plain_thresh_hi:
-            return (0, 0, 0), "plain_white_bubble"
+            bubble_over = _blend_over(mean_rgb, bubble_rgba_dynamic)
+            text_rgb = (0, 0, 0)
+            text_lum = _relative_luminance(_srgb_to_linear(np.array(text_rgb, dtype=np.float32)))
+            contrast = _contrast_ratio(
+                text_lum, _relative_luminance(_srgb_to_linear(bubble_over))
+            )
+            return bubble_rgba_dynamic, text_rgb, contrast, "forced_black_on_white_bubble", bubble_over
         if bubble_lum <= plain_thresh_lo:
-            return (255, 255, 255), "plain_black_bubble"
-        return ((0, 0, 0) if bubble_lum > 0.5 else (255, 255, 255)), "opaque_mid_bubble"
+            bubble_over = _blend_over(mean_rgb, bubble_rgba_dynamic)
+            text_rgb = (255, 255, 255)
+            text_lum = _relative_luminance(_srgb_to_linear(np.array(text_rgb, dtype=np.float32)))
+            contrast = _contrast_ratio(
+                text_lum, _relative_luminance(_srgb_to_linear(bubble_over))
+            )
+            return bubble_rgba_dynamic, text_rgb, contrast, "forced_white_on_black_bubble", bubble_over
+        if bubble_lum > 0.5:
+            bubble_over = _blend_over(mean_rgb, bubble_rgba_dynamic)
+            text_rgb = (0, 0, 0)
+            text_lum = _relative_luminance(_srgb_to_linear(np.array(text_rgb, dtype=np.float32)))
+            contrast = _contrast_ratio(
+                text_lum, _relative_luminance(_srgb_to_linear(bubble_over))
+            )
+            return bubble_rgba_dynamic, text_rgb, contrast, "opaque_mid_bubble", bubble_over
+        bubble_over = _blend_over(mean_rgb, bubble_rgba_dynamic)
+        text_rgb = (255, 255, 255)
+        text_lum = _relative_luminance(_srgb_to_linear(np.array(text_rgb, dtype=np.float32)))
+        contrast = _contrast_ratio(
+            text_lum, _relative_luminance(_srgb_to_linear(bubble_over))
+        )
+        return bubble_rgba_dynamic, text_rgb, contrast, "opaque_mid_bubble", bubble_over
 
-    if variance < flat_var:
+    if enable_plain_shortcuts and variance < flat_var:
         if mean_lum >= plain_thresh_hi:
-            return (0, 0, 0), "plain_white_bg"
+            fill_rgba = (255, 255, 255, int(plain_alpha))
+            bubble_over = _blend_over(mean_rgb, fill_rgba)
+            text_rgb = (0, 0, 0)
+            text_lum = _relative_luminance(_srgb_to_linear(np.array(text_rgb, dtype=np.float32)))
+            contrast = _contrast_ratio(
+                text_lum, _relative_luminance(_srgb_to_linear(bubble_over))
+            )
+            return fill_rgba, text_rgb, contrast, "forced_black_on_plain_white_bg", bubble_over
         if mean_lum <= plain_thresh_lo:
-            return (255, 255, 255), "plain_black_bg"
+            fill_rgba = (0, 0, 0, int(plain_alpha))
+            bubble_over = _blend_over(mean_rgb, fill_rgba)
+            text_rgb = (255, 255, 255)
+            text_lum = _relative_luminance(_srgb_to_linear(np.array(text_rgb, dtype=np.float32)))
+            contrast = _contrast_ratio(
+                text_lum, _relative_luminance(_srgb_to_linear(bubble_over))
+            )
+            return fill_rgba, text_rgb, contrast, "forced_white_on_plain_black_bg", bubble_over
 
-    return None, "use_adaptive"
+    bubble_over = _blend_over(mean_rgb, bubble_rgba_dynamic)
+    text_rgb, contrast, reason = _select_text_rgb(bubble_over, text_min_contrast)
+    return bubble_rgba_dynamic, text_rgb, contrast, reason, bubble_over
 
 
 def compute_dynamic_bubble_style(
@@ -187,6 +281,11 @@ def compute_dynamic_bubble_style(
     padding: Sequence[float] | float = (12.0, 8.0),
     text_min_contrast: float = 4.5,
     max_variance_reference: float = 0.04,
+    bubble_mode: str = "auto",
+    plain_alpha: int = 230,
+    plain_thresh_hi: float = 0.88,
+    plain_thresh_lo: float = 0.12,
+    flat_var: float = 8e-4,
 ) -> Optional[BubbleRenderStyle]:
     """Compute a dynamic bubble style for a translated text block."""
 
@@ -200,6 +299,10 @@ def compute_dynamic_bubble_style(
     bbox = _ensure_bbox_within_image(image, bbox_source)
     if bbox is None:
         return None
+
+    min_alpha = int(np.clip(min_alpha, 0, 255))
+    max_alpha = int(np.clip(max(max_alpha, min_alpha), 0, 255))
+    plain_alpha = int(np.clip(plain_alpha, 0, 255))
 
     mean_rgb, mean_lum, variance = _mean_variance_patch(image, bbox)
 
@@ -216,41 +319,28 @@ def compute_dynamic_bubble_style(
     adjusted_rgb = _clip_rgb(base_rgb + adjust)
     adjusted_rgb_tuple = _as_int_tuple(adjusted_rgb)
 
-    forced_color, reason = _pick_text_color_for_bubble(image, bbox, adjusted_rgb_tuple, alpha)
+    fill_rgba, text_rgb, contrast, reason, blended_rgb = _choose_fill_and_text(
+        mean_rgb,
+        mean_lum,
+        variance,
+        adjusted_rgb_tuple,
+        alpha,
+        bubble_mode,
+        plain_alpha,
+        plain_thresh_hi,
+        plain_thresh_lo,
+        flat_var,
+        text_min_contrast,
+    )
 
-    fill_rgba = (*adjusted_rgb_tuple, alpha)
-    blended_rgb = _blend_over(mean_rgb, fill_rgba)
     blended_lum = _relative_luminance(_srgb_to_linear(blended_rgb))
-
-    if forced_color is not None:
-        text_rgb = forced_color
-    else:
-        candidates = [
-            np.array([255.0, 255.0, 255.0], dtype=np.float32),
-            np.array([0.0, 0.0, 0.0], dtype=np.float32),
-            255.0 - blended_rgb,
-        ]
-        best_rgb = candidates[0]
-        best_ratio = -1.0
-        for cand in candidates:
-            cand_lum = _relative_luminance(_srgb_to_linear(cand))
-            ratio = _contrast_ratio(blended_lum, cand_lum)
-            if ratio > best_ratio:
-                best_ratio = ratio
-                best_rgb = cand
-            if ratio >= text_min_contrast:
-                best_rgb = cand
-                best_ratio = ratio
-                break
-        text_rgb = _as_int_tuple(best_rgb)
-        if best_ratio < text_min_contrast:
-            reason = f"low_contrast_{best_ratio:.2f}"
-
-    text_linear = _relative_luminance(_srgb_to_linear(np.array(text_rgb, dtype=np.float32)))
+    text_linear = _relative_luminance(
+        _srgb_to_linear(np.array(text_rgb, dtype=np.float32))
+    )
     outline_target = (0, 0, 0) if text_linear > blended_lum else (255, 255, 255)
     outline_rgb = outline_target
 
-    outline_width = 2.0 if alpha >= 150 else 3.0
+    outline_width = 2.0 if fill_rgba[3] >= 150 else 3.0
 
     shadow_alpha = 120 if text_linear >= blended_lum else 90
     shadow_rgb = (0, 0, 0) if text_linear >= blended_lum else (255, 255, 255)
@@ -263,6 +353,25 @@ def compute_dynamic_bubble_style(
     scale = max(1.0, 0.08 * np.sqrt(width * height) / 50.0)
     pad_l, pad_t, pad_r, pad_b = _normalise_padding(padding, scale)
     corner_radius = max(6.0, min(width, height) * corner_radius_factor)
+
+    logger.info(
+        "bubble_style mode=%s reason=%s variance=%.6f alpha=%d contrast=%.2f",
+        bubble_mode,
+        reason,
+        variance,
+        fill_rgba[3],
+        contrast,
+    )
+    if (
+        bubble_mode.lower() == "auto"
+        and not reason.startswith("dynamic")
+        and variance >= 0.0015
+    ):
+        logger.warning(
+            "auto bubble fallback triggered on busy patch (variance=%.6f, reason=%s)",
+            variance,
+            reason,
+        )
 
     return BubbleRenderStyle(
         fill_rgba=fill_rgba,

--- a/modules/rendering/render.py
+++ b/modules/rendering/render.py
@@ -55,6 +55,7 @@ class TextRenderingSettings:
     bubble_flat_var: float = 8e-4
     bubble_plain_alpha: int = 230
     text_target_contrast: float = 4.5
+    bubble_text_alpha: int = 255
     bubble_gradient_enabled: bool = False
     bubble_gradient_start: Tuple[int, int, int] = (35, 100, 160)
     bubble_gradient_end: Tuple[int, int, int] = (200, 220, 255)
@@ -361,6 +362,7 @@ def manual_wrap(
     bubble_flat_var = float(getattr(render_settings, "bubble_flat_var", 8e-4))
     bubble_plain_alpha = int(getattr(render_settings, "bubble_plain_alpha", 230))
     text_target_contrast = float(getattr(render_settings, "text_target_contrast", 4.5))
+    bubble_text_alpha = int(getattr(render_settings, "bubble_text_alpha", 255))
     bubble_gradient_enabled = bool(
         getattr(render_settings, "bubble_gradient_enabled", False)
     )
@@ -405,6 +407,7 @@ def manual_wrap(
                     plain_thresh_hi=bubble_plain_hi,
                     plain_thresh_lo=bubble_plain_lo,
                     flat_var=bubble_flat_var,
+                    text_alpha=bubble_text_alpha,
                     gradient_enabled=bubble_gradient_enabled,
                     gradient_start=bubble_gradient_start,
                     gradient_end=bubble_gradient_end,
@@ -420,6 +423,7 @@ def manual_wrap(
             text_rgb = bubble_style_obj.text_rgb
             outline_rgb = bubble_style_obj.outline_rgb
             blk.font_color = f"#{text_rgb[0]:02X}{text_rgb[1]:02X}{text_rgb[2]:02X}"
+            blk.font_alpha = int(bubble_style_obj.text_alpha)
             blk.outline_color = f"#{outline_rgb[0]:02X}{outline_rgb[1]:02X}{outline_rgb[2]:02X}"
             blk.outline_width = bubble_style_obj.outline_width
         else:
@@ -432,8 +436,10 @@ def manual_wrap(
             if decision:
                 blk.font_color = decision.text_hex
                 blk.outline_color = decision.outline_hex
+                blk.font_alpha = 255
             else:
                 blk.font_color = blk.font_color or default_text_color
+                blk.font_alpha = 255
                 if not getattr(blk, 'outline_color', ''):
                     blk.outline_color = default_outline_color if render_settings.outline else ''
 

--- a/modules/rendering/render.py
+++ b/modules/rendering/render.py
@@ -46,20 +46,21 @@ class TextRenderingSettings:
     line_spacing: str
     direction: Qt.LayoutDirection
     auto_font_color: bool = True
-    bubble_mode: str = "auto"
-    bubble_rgb: Tuple[int, int, int] = (35, 100, 160)
-    bubble_min_alpha: int = 110
-    bubble_max_alpha: int = 205
-    bubble_plain_hi: float = 0.88
-    bubble_plain_lo: float = 0.12
-    bubble_flat_var: float = 8e-4
-    bubble_plain_alpha: int = 230
+    text_color_mode: str = "auto"
+    custom_text_rgb: Tuple[int, int, int] = (0, 0, 0)
+    text_fill_opacity: float = 1.0
+    stroke_enabled: bool = False
+    stroke_width: float = 2.0
+    stroke_opacity: float = 1.0
+    auto_contrast: bool = True
     text_target_contrast: float = 4.5
-    bubble_text_alpha: int = 255
-    bubble_gradient_enabled: bool = False
-    bubble_gradient_start: Tuple[int, int, int] = (35, 100, 160)
-    bubble_gradient_end: Tuple[int, int, int] = (200, 220, 255)
-    bubble_gradient_angle: float = 90.0
+    background_box_mode: str = "off"
+    background_box_opacity: float = 0.25
+    bubble_rgb: Tuple[int, int, int] = (35, 100, 160)
+    background_plain_hi: float = 0.95
+    background_plain_lo: float = 0.05
+    flat_variance_threshold: float = 4e-4
+    auto_stroke_opacity: float = 0.6
 
 def array_to_pil(rgb_image: np.ndarray):
     # Image is already in RGB format, just convert to PIL
@@ -349,38 +350,30 @@ def manual_wrap(
     init_font_size = render_settings.max_font_size
     min_font_size = render_settings.min_font_size
 
-    bubble_mode = getattr(render_settings, "bubble_mode", "auto")
     bubble_rgb = getattr(render_settings, "bubble_rgb", (35, 100, 160))
     if isinstance(bubble_rgb, (list, tuple)):
         bubble_rgb = tuple(int(v) for v in bubble_rgb[:3])
     else:
         bubble_rgb = (35, 100, 160)
-    bubble_min_alpha = int(getattr(render_settings, "bubble_min_alpha", 110))
-    bubble_max_alpha = int(getattr(render_settings, "bubble_max_alpha", 205))
-    bubble_plain_hi = float(getattr(render_settings, "bubble_plain_hi", 0.88))
-    bubble_plain_lo = float(getattr(render_settings, "bubble_plain_lo", 0.12))
-    bubble_flat_var = float(getattr(render_settings, "bubble_flat_var", 8e-4))
-    bubble_plain_alpha = int(getattr(render_settings, "bubble_plain_alpha", 230))
+
+    text_color_mode = getattr(render_settings, "text_color_mode", "auto")
+    custom_text_rgb = getattr(render_settings, "custom_text_rgb", (0, 0, 0))
+    if isinstance(custom_text_rgb, (list, tuple)):
+        custom_text_rgb = tuple(int(v) for v in custom_text_rgb[:3])
+    else:
+        custom_text_rgb = (0, 0, 0)
+    text_fill_opacity = getattr(render_settings, "text_fill_opacity", 1.0)
+    stroke_enabled = bool(getattr(render_settings, "stroke_enabled", False))
+    stroke_width = float(getattr(render_settings, "stroke_width", outline_width))
+    stroke_opacity = getattr(render_settings, "stroke_opacity", 1.0)
+    auto_contrast = bool(getattr(render_settings, "auto_contrast", True))
     text_target_contrast = float(getattr(render_settings, "text_target_contrast", 4.5))
-    bubble_text_alpha = int(getattr(render_settings, "bubble_text_alpha", 255))
-    bubble_gradient_enabled = bool(
-        getattr(render_settings, "bubble_gradient_enabled", False)
-    )
-    bubble_gradient_start = getattr(
-        render_settings, "bubble_gradient_start", bubble_rgb
-    )
-    if isinstance(bubble_gradient_start, (list, tuple)):
-        bubble_gradient_start = tuple(int(v) for v in bubble_gradient_start[:3])
-    else:
-        bubble_gradient_start = bubble_rgb
-    bubble_gradient_end = getattr(render_settings, "bubble_gradient_end", bubble_rgb)
-    if isinstance(bubble_gradient_end, (list, tuple)):
-        bubble_gradient_end = tuple(int(v) for v in bubble_gradient_end[:3])
-    else:
-        bubble_gradient_end = bubble_gradient_start
-    bubble_gradient_angle = float(
-        getattr(render_settings, "bubble_gradient_angle", 90.0)
-    )
+    background_box_mode = getattr(render_settings, "background_box_mode", "off")
+    background_box_opacity = getattr(render_settings, "background_box_opacity", 0.25)
+    background_plain_hi = float(getattr(render_settings, "background_plain_hi", 0.95))
+    background_plain_lo = float(getattr(render_settings, "background_plain_lo", 0.05))
+    flat_variance_threshold = float(getattr(render_settings, "flat_variance_threshold", 4e-4))
+    auto_stroke_opacity = getattr(render_settings, "auto_stroke_opacity", 0.6)
 
     for blk in blk_list:
         x1, y1, width, height = blk.xywh
@@ -399,19 +392,20 @@ def manual_wrap(
                     background_image,
                     blk,
                     bubble_rgb=bubble_rgb,
-                    min_alpha=bubble_min_alpha,
-                    max_alpha=bubble_max_alpha,
+                    background_box_mode=background_box_mode,
+                    background_box_opacity=background_box_opacity,
+                    text_color_mode=text_color_mode,
+                    custom_text_rgb=custom_text_rgb,
+                    text_opacity=text_fill_opacity,
+                    stroke_enabled=stroke_enabled,
+                    stroke_width=stroke_width,
+                    stroke_opacity=stroke_opacity,
+                    auto_contrast=auto_contrast,
                     text_min_contrast=text_target_contrast,
-                    bubble_mode=bubble_mode,
-                    plain_alpha=bubble_plain_alpha,
-                    plain_thresh_hi=bubble_plain_hi,
-                    plain_thresh_lo=bubble_plain_lo,
-                    flat_var=bubble_flat_var,
-                    text_alpha=bubble_text_alpha,
-                    gradient_enabled=bubble_gradient_enabled,
-                    gradient_start=bubble_gradient_start,
-                    gradient_end=bubble_gradient_end,
-                    gradient_angle=bubble_gradient_angle,
+                    background_plain_hi=background_plain_hi,
+                    background_plain_lo=background_plain_lo,
+                    flat_variance_threshold=flat_variance_threshold,
+                    auto_stroke_opacity=auto_stroke_opacity,
                 )
             except Exception:
                 bubble_style_obj = None
@@ -424,7 +418,14 @@ def manual_wrap(
             outline_rgb = bubble_style_obj.outline_rgb
             blk.font_color = f"#{text_rgb[0]:02X}{text_rgb[1]:02X}{text_rgb[2]:02X}"
             blk.font_alpha = int(bubble_style_obj.text_alpha)
-            blk.outline_color = f"#{outline_rgb[0]:02X}{outline_rgb[1]:02X}{outline_rgb[2]:02X}"
+            outline_alpha = int(bubble_style_obj.outline_alpha)
+            blk.outline_alpha = outline_alpha
+            if outline_alpha > 0 and bubble_style_obj.outline_width > 0:
+                blk.outline_color = (
+                    f"#{outline_alpha:02X}{outline_rgb[0]:02X}{outline_rgb[1]:02X}{outline_rgb[2]:02X}"
+                )
+            else:
+                blk.outline_color = ''
             blk.outline_width = bubble_style_obj.outline_width
         else:
             if auto_font_color and classifier and background_image is not None:

--- a/modules/rendering/render.py
+++ b/modules/rendering/render.py
@@ -55,6 +55,10 @@ class TextRenderingSettings:
     bubble_flat_var: float = 8e-4
     bubble_plain_alpha: int = 230
     text_target_contrast: float = 4.5
+    bubble_gradient_enabled: bool = False
+    bubble_gradient_start: Tuple[int, int, int] = (35, 100, 160)
+    bubble_gradient_end: Tuple[int, int, int] = (200, 220, 255)
+    bubble_gradient_angle: float = 90.0
 
 def array_to_pil(rgb_image: np.ndarray):
     # Image is already in RGB format, just convert to PIL
@@ -357,6 +361,24 @@ def manual_wrap(
     bubble_flat_var = float(getattr(render_settings, "bubble_flat_var", 8e-4))
     bubble_plain_alpha = int(getattr(render_settings, "bubble_plain_alpha", 230))
     text_target_contrast = float(getattr(render_settings, "text_target_contrast", 4.5))
+    bubble_gradient_enabled = bool(
+        getattr(render_settings, "bubble_gradient_enabled", False)
+    )
+    bubble_gradient_start = getattr(
+        render_settings, "bubble_gradient_start", bubble_rgb
+    )
+    if isinstance(bubble_gradient_start, (list, tuple)):
+        bubble_gradient_start = tuple(int(v) for v in bubble_gradient_start[:3])
+    else:
+        bubble_gradient_start = bubble_rgb
+    bubble_gradient_end = getattr(render_settings, "bubble_gradient_end", bubble_rgb)
+    if isinstance(bubble_gradient_end, (list, tuple)):
+        bubble_gradient_end = tuple(int(v) for v in bubble_gradient_end[:3])
+    else:
+        bubble_gradient_end = bubble_gradient_start
+    bubble_gradient_angle = float(
+        getattr(render_settings, "bubble_gradient_angle", 90.0)
+    )
 
     for blk in blk_list:
         x1, y1, width, height = blk.xywh
@@ -383,6 +405,10 @@ def manual_wrap(
                     plain_thresh_hi=bubble_plain_hi,
                     plain_thresh_lo=bubble_plain_lo,
                     flat_var=bubble_flat_var,
+                    gradient_enabled=bubble_gradient_enabled,
+                    gradient_start=bubble_gradient_start,
+                    gradient_end=bubble_gradient_end,
+                    gradient_angle=bubble_gradient_angle,
                 )
             except Exception:
                 bubble_style_obj = None

--- a/modules/rendering/render.py
+++ b/modules/rendering/render.py
@@ -369,14 +369,7 @@ def manual_wrap(
         blk.outline_width = float(getattr(blk, "outline_width", outline_width))
 
         bubble_style_obj = None
-        if (
-            auto_font_color
-            and background_image is not None
-            and (
-                getattr(blk, "text_class", "") == "text_bubble"
-                or getattr(blk, "bubble_xyxy", None) is not None
-            )
-        ):
+        if auto_font_color and background_image is not None:
             try:
                 bubble_style_obj = compute_dynamic_bubble_style(
                     background_image,

--- a/modules/utils/textblock.py
+++ b/modules/utils/textblock.py
@@ -56,6 +56,8 @@ class TextBlock(object):
         self.max_font_size = max_font_size
         self.font_color = font_color
         self.outline_color = outline_color
+        self.outline_width = kwargs.get('outline_width', kwargs.get('outlineWidth', 1.0))
+        self.bubble_style = kwargs.get('bubble_style')
 
     @property
     def xywh(self):
@@ -106,6 +108,8 @@ class TextBlock(object):
         new_block.max_font_size = self.max_font_size
         new_block.font_color = self.font_color
         new_block.outline_color = self.outline_color
+        new_block.outline_width = getattr(self, 'outline_width', 1.0)
+        new_block.bubble_style = copy.deepcopy(getattr(self, 'bubble_style', None))
         
         return new_block
 

--- a/modules/utils/textblock.py
+++ b/modules/utils/textblock.py
@@ -27,6 +27,7 @@ class TextBlock(object):
                  min_font_size: int = 0,
                  max_font_size: int = 0,
                  font_color: str = "",
+                 font_alpha: int = 255,
                  outline_color: str = "",
                  **kwargs) -> None:
         
@@ -55,6 +56,7 @@ class TextBlock(object):
         self.min_font_size = min_font_size
         self.max_font_size = max_font_size
         self.font_color = font_color
+        self.font_alpha = int(font_alpha)
         self.outline_color = outline_color
         self.outline_width = kwargs.get('outline_width', kwargs.get('outlineWidth', 1.0))
         self.bubble_style = kwargs.get('bubble_style')
@@ -107,6 +109,7 @@ class TextBlock(object):
         new_block.min_font_size = self.min_font_size
         new_block.max_font_size = self.max_font_size
         new_block.font_color = self.font_color
+        new_block.font_alpha = getattr(self, 'font_alpha', 255)
         new_block.outline_color = self.outline_color
         new_block.outline_width = getattr(self, 'outline_width', 1.0)
         new_block.bubble_style = copy.deepcopy(getattr(self, 'bubble_style', None))

--- a/pipeline/batch_processor.py
+++ b/pipeline/batch_processor.py
@@ -342,6 +342,20 @@ class BatchProcessor:
                 else image
             )
 
+            bubble_mode = getattr(render_settings, 'bubble_mode', 'auto')
+            bubble_rgb = getattr(render_settings, 'bubble_rgb', (35, 100, 160))
+            if isinstance(bubble_rgb, (list, tuple)):
+                bubble_rgb = tuple(int(v) for v in bubble_rgb[:3])
+            else:
+                bubble_rgb = (35, 100, 160)
+            bubble_min_alpha = int(getattr(render_settings, 'bubble_min_alpha', 110))
+            bubble_max_alpha = int(getattr(render_settings, 'bubble_max_alpha', 205))
+            bubble_plain_hi = float(getattr(render_settings, 'bubble_plain_hi', 0.88))
+            bubble_plain_lo = float(getattr(render_settings, 'bubble_plain_lo', 0.12))
+            bubble_flat_var = float(getattr(render_settings, 'bubble_flat_var', 8e-4))
+            bubble_plain_alpha = int(getattr(render_settings, 'bubble_plain_alpha', 230))
+            text_target_contrast = float(getattr(render_settings, 'text_target_contrast', 4.5))
+
             text_items_state = []
             for blk in blk_list:
                 x1, y1, width, height = blk.xywh
@@ -367,7 +381,19 @@ class BatchProcessor:
                     )
                 ):
                     try:
-                        bubble_style_obj = compute_dynamic_bubble_style(background_for_sampling, blk)
+                        bubble_style_obj = compute_dynamic_bubble_style(
+                            background_for_sampling,
+                            blk,
+                            bubble_rgb=bubble_rgb,
+                            min_alpha=bubble_min_alpha,
+                            max_alpha=bubble_max_alpha,
+                            text_min_contrast=text_target_contrast,
+                            bubble_mode=bubble_mode,
+                            plain_alpha=bubble_plain_alpha,
+                            plain_thresh_hi=bubble_plain_hi,
+                            plain_thresh_lo=bubble_plain_lo,
+                            flat_var=bubble_flat_var,
+                        )
                     except Exception:
                         logger.exception("Dynamic bubble styling failed for block")
                         bubble_style_obj = None

--- a/pipeline/batch_processor.py
+++ b/pipeline/batch_processor.py
@@ -372,14 +372,7 @@ class BatchProcessor:
                 blk.outline_width = outline_width
 
                 bubble_style_obj = None
-                if (
-                    auto_font_color
-                    and background_for_sampling is not None
-                    and (
-                        getattr(blk, 'text_class', '') == 'text_bubble'
-                        or getattr(blk, 'bubble_xyxy', None) is not None
-                    )
-                ):
+                if auto_font_color and background_for_sampling is not None:
                     try:
                         bubble_style_obj = compute_dynamic_bubble_style(
                             background_for_sampling,

--- a/pipeline/batch_processor.py
+++ b/pipeline/batch_processor.py
@@ -355,6 +355,26 @@ class BatchProcessor:
             bubble_flat_var = float(getattr(render_settings, 'bubble_flat_var', 8e-4))
             bubble_plain_alpha = int(getattr(render_settings, 'bubble_plain_alpha', 230))
             text_target_contrast = float(getattr(render_settings, 'text_target_contrast', 4.5))
+            bubble_gradient_enabled = bool(
+                getattr(render_settings, 'bubble_gradient_enabled', False)
+            )
+            bubble_gradient_start = getattr(
+                render_settings, 'bubble_gradient_start', bubble_rgb
+            )
+            if isinstance(bubble_gradient_start, (list, tuple)):
+                bubble_gradient_start = tuple(int(v) for v in bubble_gradient_start[:3])
+            else:
+                bubble_gradient_start = bubble_rgb
+            bubble_gradient_end = getattr(
+                render_settings, 'bubble_gradient_end', bubble_gradient_start
+            )
+            if isinstance(bubble_gradient_end, (list, tuple)):
+                bubble_gradient_end = tuple(int(v) for v in bubble_gradient_end[:3])
+            else:
+                bubble_gradient_end = bubble_gradient_start
+            bubble_gradient_angle = float(
+                getattr(render_settings, 'bubble_gradient_angle', 90.0)
+            )
 
             text_items_state = []
             for blk in blk_list:
@@ -386,6 +406,10 @@ class BatchProcessor:
                             plain_thresh_hi=bubble_plain_hi,
                             plain_thresh_lo=bubble_plain_lo,
                             flat_var=bubble_flat_var,
+                            gradient_enabled=bubble_gradient_enabled,
+                            gradient_start=bubble_gradient_start,
+                            gradient_end=bubble_gradient_end,
+                            gradient_angle=bubble_gradient_angle,
                         )
                     except Exception:
                         logger.exception("Dynamic bubble styling failed for block")

--- a/pipeline/batch_processor.py
+++ b/pipeline/batch_processor.py
@@ -355,6 +355,7 @@ class BatchProcessor:
             bubble_flat_var = float(getattr(render_settings, 'bubble_flat_var', 8e-4))
             bubble_plain_alpha = int(getattr(render_settings, 'bubble_plain_alpha', 230))
             text_target_contrast = float(getattr(render_settings, 'text_target_contrast', 4.5))
+            bubble_text_alpha = int(getattr(render_settings, 'bubble_text_alpha', 255))
             bubble_gradient_enabled = bool(
                 getattr(render_settings, 'bubble_gradient_enabled', False)
             )
@@ -406,6 +407,7 @@ class BatchProcessor:
                             plain_thresh_hi=bubble_plain_hi,
                             plain_thresh_lo=bubble_plain_lo,
                             flat_var=bubble_flat_var,
+                            text_alpha=bubble_text_alpha,
                             gradient_enabled=bubble_gradient_enabled,
                             gradient_start=bubble_gradient_start,
                             gradient_end=bubble_gradient_end,
@@ -428,9 +430,15 @@ class BatchProcessor:
                     text_hex = f"#{text_rgb[0]:02X}{text_rgb[1]:02X}{text_rgb[2]:02X}"
                     outline_hex = f"#{outline_rgb[0]:02X}{outline_rgb[1]:02X}{outline_rgb[2]:02X}"
                     blk.font_color = text_hex
+                    blk.font_alpha = int(bubble_style_obj.text_alpha)
                     blk.outline_color = outline_hex
                     blk.outline_width = bubble_style_obj.outline_width
-                    text_color = QColor(*text_rgb)
+                    text_color = QColor(
+                        int(text_rgb[0]),
+                        int(text_rgb[1]),
+                        int(text_rgb[2]),
+                        int(bubble_style_obj.text_alpha),
+                    )
                     outline_color = QColor(*outline_rgb)
                     effective_outline_width = bubble_style_obj.outline_width
                 else:
@@ -446,12 +454,16 @@ class BatchProcessor:
                     if decision:
                         blk.font_color = decision.text_hex
                         blk.outline_color = decision.outline_hex
+                        blk.font_alpha = 255
                         text_color = QColor(decision.text_hex)
+                        text_color.setAlpha(255)
                         outline_color = QColor(decision.outline_hex)
                     else:
                         if not getattr(blk, 'font_color', ''):
                             blk.font_color = default_text_color.name()
+                        blk.font_alpha = int(getattr(blk, 'font_alpha', 255) or 255)
                         text_color = QColor(blk.font_color)
+                        text_color.setAlpha(int(blk.font_alpha))
                         if getattr(blk, 'outline_color', ''):
                             outline_color = QColor(blk.outline_color)
                         elif render_settings.outline:

--- a/pipeline/batch_processor.py
+++ b/pipeline/batch_processor.py
@@ -342,40 +342,32 @@ class BatchProcessor:
                 else image
             )
 
-            bubble_mode = getattr(render_settings, 'bubble_mode', 'auto')
             bubble_rgb = getattr(render_settings, 'bubble_rgb', (35, 100, 160))
             if isinstance(bubble_rgb, (list, tuple)):
                 bubble_rgb = tuple(int(v) for v in bubble_rgb[:3])
             else:
                 bubble_rgb = (35, 100, 160)
-            bubble_min_alpha = int(getattr(render_settings, 'bubble_min_alpha', 110))
-            bubble_max_alpha = int(getattr(render_settings, 'bubble_max_alpha', 205))
-            bubble_plain_hi = float(getattr(render_settings, 'bubble_plain_hi', 0.88))
-            bubble_plain_lo = float(getattr(render_settings, 'bubble_plain_lo', 0.12))
-            bubble_flat_var = float(getattr(render_settings, 'bubble_flat_var', 8e-4))
-            bubble_plain_alpha = int(getattr(render_settings, 'bubble_plain_alpha', 230))
+
+            text_color_mode = getattr(render_settings, 'text_color_mode', 'auto')
+            custom_text_rgb = getattr(render_settings, 'custom_text_rgb', (0, 0, 0))
+            if isinstance(custom_text_rgb, (list, tuple)):
+                custom_text_rgb = tuple(int(v) for v in custom_text_rgb[:3])
+            else:
+                custom_text_rgb = (0, 0, 0)
+
+            text_fill_opacity = getattr(render_settings, 'text_fill_opacity', 1.0)
+            stroke_enabled = bool(getattr(render_settings, 'stroke_enabled', False))
+            stroke_width = float(getattr(render_settings, 'stroke_width', outline_width))
+            stroke_opacity = getattr(render_settings, 'stroke_opacity', 1.0)
+            auto_contrast = bool(getattr(render_settings, 'auto_contrast', True))
             text_target_contrast = float(getattr(render_settings, 'text_target_contrast', 4.5))
-            bubble_text_alpha = int(getattr(render_settings, 'bubble_text_alpha', 255))
-            bubble_gradient_enabled = bool(
-                getattr(render_settings, 'bubble_gradient_enabled', False)
-            )
-            bubble_gradient_start = getattr(
-                render_settings, 'bubble_gradient_start', bubble_rgb
-            )
-            if isinstance(bubble_gradient_start, (list, tuple)):
-                bubble_gradient_start = tuple(int(v) for v in bubble_gradient_start[:3])
-            else:
-                bubble_gradient_start = bubble_rgb
-            bubble_gradient_end = getattr(
-                render_settings, 'bubble_gradient_end', bubble_gradient_start
-            )
-            if isinstance(bubble_gradient_end, (list, tuple)):
-                bubble_gradient_end = tuple(int(v) for v in bubble_gradient_end[:3])
-            else:
-                bubble_gradient_end = bubble_gradient_start
-            bubble_gradient_angle = float(
-                getattr(render_settings, 'bubble_gradient_angle', 90.0)
-            )
+
+            background_box_mode = getattr(render_settings, 'background_box_mode', 'off')
+            background_box_opacity = getattr(render_settings, 'background_box_opacity', 0.25)
+            background_plain_hi = float(getattr(render_settings, 'background_plain_hi', 0.95))
+            background_plain_lo = float(getattr(render_settings, 'background_plain_lo', 0.05))
+            bubble_flat_var = float(getattr(render_settings, 'flat_variance_threshold', 4e-4))
+            auto_stroke_opacity = getattr(render_settings, 'auto_stroke_opacity', 0.6)
 
             text_items_state = []
             for blk in blk_list:
@@ -399,19 +391,20 @@ class BatchProcessor:
                             background_for_sampling,
                             blk,
                             bubble_rgb=bubble_rgb,
-                            min_alpha=bubble_min_alpha,
-                            max_alpha=bubble_max_alpha,
+                            background_box_mode=background_box_mode,
+                            background_box_opacity=background_box_opacity,
+                            text_color_mode=text_color_mode,
+                            custom_text_rgb=custom_text_rgb,
+                            text_opacity=text_fill_opacity,
+                            stroke_enabled=stroke_enabled,
+                            stroke_width=stroke_width,
+                            stroke_opacity=stroke_opacity,
+                            auto_contrast=auto_contrast,
                             text_min_contrast=text_target_contrast,
-                            bubble_mode=bubble_mode,
-                            plain_alpha=bubble_plain_alpha,
-                            plain_thresh_hi=bubble_plain_hi,
-                            plain_thresh_lo=bubble_plain_lo,
-                            flat_var=bubble_flat_var,
-                            text_alpha=bubble_text_alpha,
-                            gradient_enabled=bubble_gradient_enabled,
-                            gradient_start=bubble_gradient_start,
-                            gradient_end=bubble_gradient_end,
-                            gradient_angle=bubble_gradient_angle,
+                            background_plain_hi=background_plain_hi,
+                            background_plain_lo=background_plain_lo,
+                            flat_variance_threshold=bubble_flat_var,
+                            auto_stroke_opacity=auto_stroke_opacity,
                         )
                     except Exception:
                         logger.exception("Dynamic bubble styling failed for block")
@@ -428,10 +421,16 @@ class BatchProcessor:
                     text_rgb = bubble_style_obj.text_rgb
                     outline_rgb = bubble_style_obj.outline_rgb
                     text_hex = f"#{text_rgb[0]:02X}{text_rgb[1]:02X}{text_rgb[2]:02X}"
-                    outline_hex = f"#{outline_rgb[0]:02X}{outline_rgb[1]:02X}{outline_rgb[2]:02X}"
                     blk.font_color = text_hex
                     blk.font_alpha = int(bubble_style_obj.text_alpha)
-                    blk.outline_color = outline_hex
+                    outline_alpha = int(bubble_style_obj.outline_alpha)
+                    blk.outline_alpha = outline_alpha
+                    if outline_alpha > 0 and bubble_style_obj.outline_width > 0:
+                        blk.outline_color = (
+                            f"#{outline_alpha:02X}{outline_rgb[0]:02X}{outline_rgb[1]:02X}{outline_rgb[2]:02X}"
+                        )
+                    else:
+                        blk.outline_color = ''
                     blk.outline_width = bubble_style_obj.outline_width
                     text_color = QColor(
                         int(text_rgb[0]),
@@ -439,7 +438,15 @@ class BatchProcessor:
                         int(text_rgb[2]),
                         int(bubble_style_obj.text_alpha),
                     )
-                    outline_color = QColor(*outline_rgb)
+                    if outline_alpha > 0:
+                        outline_color = QColor(
+                            int(outline_rgb[0]),
+                            int(outline_rgb[1]),
+                            int(outline_rgb[2]),
+                            outline_alpha,
+                        )
+                    else:
+                        outline_color = QColor(*outline_rgb)
                     effective_outline_width = bubble_style_obj.outline_width
                 else:
                     if auto_font_color and self.text_color_classifier and background_for_sampling is not None:

--- a/pipeline/webtoon_batch_processor.py
+++ b/pipeline/webtoon_batch_processor.py
@@ -788,6 +788,7 @@ class WebtoonBatchProcessor:
         bubble_flat_var = float(getattr(render_settings, 'bubble_flat_var', 8e-4))
         bubble_plain_alpha = int(getattr(render_settings, 'bubble_plain_alpha', 230))
         text_target_contrast = float(getattr(render_settings, 'text_target_contrast', 4.5))
+        bubble_text_alpha = int(getattr(render_settings, 'bubble_text_alpha', 255))
         bubble_gradient_enabled = bool(
             getattr(render_settings, 'bubble_gradient_enabled', False)
         )
@@ -861,11 +862,12 @@ class WebtoonBatchProcessor:
                         max_alpha=bubble_max_alpha,
                         text_min_contrast=text_target_contrast,
                         bubble_mode=bubble_mode,
-                            plain_alpha=bubble_plain_alpha,
-                            plain_thresh_hi=bubble_plain_hi,
-                            plain_thresh_lo=bubble_plain_lo,
-                            flat_var=bubble_flat_var,
-                            gradient_enabled=bubble_gradient_enabled,
+                        plain_alpha=bubble_plain_alpha,
+                        plain_thresh_hi=bubble_plain_hi,
+                        plain_thresh_lo=bubble_plain_lo,
+                        flat_var=bubble_flat_var,
+                        text_alpha=bubble_text_alpha,
+                        gradient_enabled=bubble_gradient_enabled,
                             gradient_start=bubble_gradient_start,
                             gradient_end=bubble_gradient_end,
                             gradient_angle=bubble_gradient_angle,
@@ -887,9 +889,15 @@ class WebtoonBatchProcessor:
                 text_hex = f"#{text_rgb[0]:02X}{text_rgb[1]:02X}{text_rgb[2]:02X}"
                 outline_hex = f"#{outline_rgb[0]:02X}{outline_rgb[1]:02X}{outline_rgb[2]:02X}"
                 blk_virtual.font_color = text_hex
+                blk_virtual.font_alpha = int(bubble_style_obj.text_alpha)
                 blk_virtual.outline_color = outline_hex
                 blk_virtual.outline_width = bubble_style_obj.outline_width
-                text_color = QColor(*text_rgb)
+                text_color = QColor(
+                    int(text_rgb[0]),
+                    int(text_rgb[1]),
+                    int(text_rgb[2]),
+                    int(bubble_style_obj.text_alpha),
+                )
                 outline_color = QColor(*outline_rgb)
                 effective_outline_width = bubble_style_obj.outline_width
             else:
@@ -903,12 +911,16 @@ class WebtoonBatchProcessor:
                 if decision:
                     blk_virtual.font_color = decision.text_hex
                     blk_virtual.outline_color = decision.outline_hex
+                    blk_virtual.font_alpha = 255
                     text_color = QColor(decision.text_hex)
+                    text_color.setAlpha(255)
                     outline_color = QColor(decision.outline_hex)
                 else:
                     if not getattr(blk_virtual, 'font_color', ''):
                         blk_virtual.font_color = default_text_color.name()
+                    blk_virtual.font_alpha = int(getattr(blk_virtual, 'font_alpha', 255) or 255)
                     text_color = QColor(blk_virtual.font_color)
+                    text_color.setAlpha(int(blk_virtual.font_alpha))
                     if getattr(blk_virtual, 'outline_color', ''):
                         outline_color = QColor(blk_virtual.outline_color)
                     elif outline:
@@ -933,6 +945,7 @@ class WebtoonBatchProcessor:
 
             render_blk.translation = translation
             render_blk.font_color = blk_virtual.font_color
+            render_blk.font_alpha = getattr(blk_virtual, 'font_alpha', 255)
             render_blk.outline_color = blk_virtual.outline_color
             render_blk.outline_width = getattr(blk_virtual, 'outline_width', outline_width)
             render_blk.bubble_style = getattr(blk_virtual, 'bubble_style', None)

--- a/pipeline/webtoon_batch_processor.py
+++ b/pipeline/webtoon_batch_processor.py
@@ -775,6 +775,20 @@ class WebtoonBatchProcessor:
         direction = render_settings.direction
         auto_font_color = getattr(render_settings, 'auto_font_color', True)
 
+        bubble_mode = getattr(render_settings, 'bubble_mode', 'auto')
+        bubble_rgb = getattr(render_settings, 'bubble_rgb', (35, 100, 160))
+        if isinstance(bubble_rgb, (list, tuple)):
+            bubble_rgb = tuple(int(v) for v in bubble_rgb[:3])
+        else:
+            bubble_rgb = (35, 100, 160)
+        bubble_min_alpha = int(getattr(render_settings, 'bubble_min_alpha', 110))
+        bubble_max_alpha = int(getattr(render_settings, 'bubble_max_alpha', 205))
+        bubble_plain_hi = float(getattr(render_settings, 'bubble_plain_hi', 0.88))
+        bubble_plain_lo = float(getattr(render_settings, 'bubble_plain_lo', 0.12))
+        bubble_flat_var = float(getattr(render_settings, 'bubble_flat_var', 8e-4))
+        bubble_plain_alpha = int(getattr(render_settings, 'bubble_plain_alpha', 230))
+        text_target_contrast = float(getattr(render_settings, 'text_target_contrast', 4.5))
+
         backgrounds = self.virtual_page_backgrounds.get(vpage.virtual_id, [])
         background_image = None
         if backgrounds:
@@ -826,7 +840,19 @@ class WebtoonBatchProcessor:
                 )
             ):
                 try:
-                    bubble_style_obj = compute_dynamic_bubble_style(background_image, blk_virtual)
+                    bubble_style_obj = compute_dynamic_bubble_style(
+                        background_image,
+                        blk_virtual,
+                        bubble_rgb=bubble_rgb,
+                        min_alpha=bubble_min_alpha,
+                        max_alpha=bubble_max_alpha,
+                        text_min_contrast=text_target_contrast,
+                        bubble_mode=bubble_mode,
+                        plain_alpha=bubble_plain_alpha,
+                        plain_thresh_hi=bubble_plain_hi,
+                        plain_thresh_lo=bubble_plain_lo,
+                        flat_var=bubble_flat_var,
+                    )
                 except Exception:
                     logger.exception("Dynamic bubble styling failed for virtual page %s", vpage.virtual_id)
                     bubble_style_obj = None

--- a/pipeline/webtoon_batch_processor.py
+++ b/pipeline/webtoon_batch_processor.py
@@ -831,14 +831,7 @@ class WebtoonBatchProcessor:
             blk_virtual.outline_width = outline_width
 
             bubble_style_obj = None
-            if (
-                auto_font_color
-                and background_image is not None
-                and (
-                    getattr(blk_virtual, 'text_class', '') == 'text_bubble'
-                    or getattr(blk_virtual, 'bubble_xyxy', None) is not None
-                )
-            ):
+            if auto_font_color and background_image is not None:
                 try:
                     bubble_style_obj = compute_dynamic_bubble_style(
                         background_image,

--- a/pipeline/webtoon_batch_processor.py
+++ b/pipeline/webtoon_batch_processor.py
@@ -788,6 +788,26 @@ class WebtoonBatchProcessor:
         bubble_flat_var = float(getattr(render_settings, 'bubble_flat_var', 8e-4))
         bubble_plain_alpha = int(getattr(render_settings, 'bubble_plain_alpha', 230))
         text_target_contrast = float(getattr(render_settings, 'text_target_contrast', 4.5))
+        bubble_gradient_enabled = bool(
+            getattr(render_settings, 'bubble_gradient_enabled', False)
+        )
+        bubble_gradient_start = getattr(
+            render_settings, 'bubble_gradient_start', bubble_rgb
+        )
+        if isinstance(bubble_gradient_start, (list, tuple)):
+            bubble_gradient_start = tuple(int(v) for v in bubble_gradient_start[:3])
+        else:
+            bubble_gradient_start = bubble_rgb
+        bubble_gradient_end = getattr(
+            render_settings, 'bubble_gradient_end', bubble_gradient_start
+        )
+        if isinstance(bubble_gradient_end, (list, tuple)):
+            bubble_gradient_end = tuple(int(v) for v in bubble_gradient_end[:3])
+        else:
+            bubble_gradient_end = bubble_gradient_start
+        bubble_gradient_angle = float(
+            getattr(render_settings, 'bubble_gradient_angle', 90.0)
+        )
 
         backgrounds = self.virtual_page_backgrounds.get(vpage.virtual_id, [])
         background_image = None
@@ -841,11 +861,15 @@ class WebtoonBatchProcessor:
                         max_alpha=bubble_max_alpha,
                         text_min_contrast=text_target_contrast,
                         bubble_mode=bubble_mode,
-                        plain_alpha=bubble_plain_alpha,
-                        plain_thresh_hi=bubble_plain_hi,
-                        plain_thresh_lo=bubble_plain_lo,
-                        flat_var=bubble_flat_var,
-                    )
+                            plain_alpha=bubble_plain_alpha,
+                            plain_thresh_hi=bubble_plain_hi,
+                            plain_thresh_lo=bubble_plain_lo,
+                            flat_var=bubble_flat_var,
+                            gradient_enabled=bubble_gradient_enabled,
+                            gradient_start=bubble_gradient_start,
+                            gradient_end=bubble_gradient_end,
+                            gradient_angle=bubble_gradient_angle,
+                        )
                 except Exception:
                     logger.exception("Dynamic bubble styling failed for virtual page %s", vpage.virtual_id)
                     bubble_style_obj = None

--- a/tests/test_dynamic_bubble.py
+++ b/tests/test_dynamic_bubble.py
@@ -35,3 +35,24 @@ def test_translucent_mode_keeps_high_opacity():
     assert style.fill_rgba[3] >= 225
     assert style.text_rgb == (255, 255, 255)
     assert style.reason.startswith("dynamic")
+
+
+def test_gradient_arguments_generate_fill_gradient():
+    image = np.full((200, 200, 3), 200, dtype=np.uint8)
+    blk = _make_block()
+
+    style = compute_dynamic_bubble_style(
+        image,
+        blk,
+        bubble_mode="auto",
+        gradient_enabled=True,
+        gradient_start=(30, 90, 150),
+        gradient_end=(220, 240, 255),
+        gradient_angle=45.0,
+    )
+
+    assert style is not None
+    assert style.fill_gradient is not None
+    assert style.fill_gradient['angle'] == 45.0
+    assert tuple(style.fill_gradient['start_rgba'][:3]) == (30, 90, 150)
+    assert style.fill_gradient['start_rgba'][3] == style.fill_rgba[3]

--- a/tests/test_dynamic_bubble.py
+++ b/tests/test_dynamic_bubble.py
@@ -54,9 +54,24 @@ def test_dynamic_background_selects_high_contrast_text():
     assert style is not None
     assert style.fill_rgba[3] == 0
     assert style.text_rgb in {(0, 0, 0), (255, 255, 255)}
-    assert style.reason.startswith("dynamic")
+    assert style.reason.startswith(("dynamic", "plain_"))
     # Contrast should meet or exceed the WCAG target of 4.5:1
     assert style.outline_alpha in (0, 153)
+
+
+def test_foreground_text_does_not_confuse_background_sampling():
+    image = np.full((140, 140, 3), 35, dtype=np.uint8)
+    # Simulate bright foreground strokes inside the bubble.
+    image[60:80, 40:100] = 240
+    blk = _make_block(30, 30, 110, 110)
+
+    style = compute_dynamic_bubble_style(image, blk)
+
+    assert style is not None
+    assert style.fill_rgba[3] == 0
+    # Dark background should produce white text even though bright strokes exist.
+    assert style.text_rgb == (255, 255, 255)
+    assert style.outline_rgb == (0, 0, 0)
 
 
 def test_custom_colour_with_auto_contrast_adds_outline():

--- a/tests/test_dynamic_bubble.py
+++ b/tests/test_dynamic_bubble.py
@@ -21,6 +21,7 @@ def test_auto_mode_produces_tinted_bubble_on_plain_background():
     assert style.fill_rgba[3] >= 200
     # Prefer white text similar to the reference look.
     assert style.text_rgb == (255, 255, 255)
+    assert style.text_alpha == 255
     assert style.reason.startswith("dynamic")
 
 
@@ -34,6 +35,7 @@ def test_translucent_mode_keeps_high_opacity():
     assert style.fill_rgba[:3] != (255, 255, 255)
     assert style.fill_rgba[3] >= 225
     assert style.text_rgb == (255, 255, 255)
+    assert style.text_alpha == 255
     assert style.reason.startswith("dynamic")
 
 

--- a/tests/test_dynamic_bubble.py
+++ b/tests/test_dynamic_bubble.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+from modules.rendering.dynamic_bubble import compute_dynamic_bubble_style
+from modules.utils.textblock import TextBlock
+
+
+def _make_block(x0=40, y0=40, x1=160, y1=120):
+    bbox = [int(x0), int(y0), int(x1), int(y1)]
+    return TextBlock(text_bbox=bbox, bubble_bbox=list(bbox))
+
+
+def test_auto_mode_produces_tinted_bubble_on_plain_background():
+    image = np.full((200, 200, 3), 240, dtype=np.uint8)
+    blk = _make_block()
+
+    style = compute_dynamic_bubble_style(image, blk, bubble_mode="auto")
+
+    assert style is not None
+    # Bubble should remain tinted (not plain white) and reasonably opaque.
+    assert style.fill_rgba[:3] != (255, 255, 255)
+    assert style.fill_rgba[3] >= 200
+    # Prefer white text similar to the reference look.
+    assert style.text_rgb == (255, 255, 255)
+    assert style.reason.startswith("dynamic")
+
+
+def test_translucent_mode_keeps_high_opacity():
+    image = np.full((200, 200, 3), 245, dtype=np.uint8)
+    blk = _make_block()
+
+    style = compute_dynamic_bubble_style(image, blk, bubble_mode="translucent")
+
+    assert style is not None
+    assert style.fill_rgba[:3] != (255, 255, 255)
+    assert style.fill_rgba[3] >= 225
+    assert style.text_rgb == (255, 255, 255)
+    assert style.reason.startswith("dynamic")

--- a/tests/test_dynamic_bubble.py
+++ b/tests/test_dynamic_bubble.py
@@ -70,8 +70,8 @@ def test_foreground_text_does_not_confuse_background_sampling():
     assert style is not None
     assert style.fill_rgba[3] == 0
     # Dark background should produce white text even though bright strokes exist.
-    assert style.text_rgb == (255, 255, 255)
-    assert style.outline_rgb == (0, 0, 0)
+    assert all(channel >= 220 for channel in style.text_rgb)
+    assert all(channel <= 40 for channel in style.outline_rgb)
 
 
 def test_custom_colour_with_auto_contrast_adds_outline():

--- a/tests/test_dynamic_bubble.py
+++ b/tests/test_dynamic_bubble.py
@@ -1,6 +1,9 @@
 import numpy as np
 
-from modules.rendering.dynamic_bubble import compute_dynamic_bubble_style
+from modules.rendering.dynamic_bubble import (
+    compute_dynamic_bubble_style,
+    image_overlaps_any_block,
+)
 from modules.utils.textblock import TextBlock
 
 
@@ -115,3 +118,12 @@ def test_auto_background_box_adds_tint_when_contrast_low():
     assert style.fill_rgba[3] > 0
     assert style.fill_rgba[:3] == (35, 100, 160)
     assert style.fill_rgba[3] <= int(0.3 * 255 + 1)
+
+
+def test_image_cover_check_ignores_out_of_bounds_blocks():
+    image = np.zeros((120, 120, 3), dtype=np.uint8)
+    valid = TextBlock(text_bbox=[10, 10, 40, 40], bubble_bbox=[10, 10, 40, 40])
+    offscreen = TextBlock(text_bbox=[150, 150, 210, 220], bubble_bbox=[150, 150, 210, 220])
+
+    assert image_overlaps_any_block(image, [offscreen, valid])
+    assert not image_overlaps_any_block(image, [offscreen])

--- a/tests/test_dynamic_bubble.py
+++ b/tests/test_dynamic_bubble.py
@@ -58,3 +58,22 @@ def test_gradient_arguments_generate_fill_gradient():
     assert style.fill_gradient['angle'] == 45.0
     assert tuple(style.fill_gradient['start_rgba'][:3]) == (30, 90, 150)
     assert style.fill_gradient['start_rgba'][3] == style.fill_rgba[3]
+
+
+def test_numpy_bbox_and_text_alpha_override():
+    image = np.full((150, 150, 3), 180, dtype=np.uint8)
+    text_bbox = np.array([20.0, 30.0, 120.0, 110.0], dtype=np.float32)
+    bubble_bbox = np.array([18.0, 28.0, 122.0, 112.0], dtype=np.float32)
+    blk = TextBlock(text_bbox=text_bbox, bubble_bbox=bubble_bbox)
+
+    style = compute_dynamic_bubble_style(
+        image,
+        blk,
+        bubble_mode="auto",
+        text_alpha=128,
+    )
+
+    assert style is not None
+    assert style.text_alpha == 128
+    # Ensure the style remains translucent rather than dropping the bubble entirely.
+    assert style.fill_rgba[3] > 0


### PR DESCRIPTION
## Summary
- add a dynamic speech bubble styling helper that adapts opacity, contrast, and padding to the underlying art
- integrate the new styling into batch and webtoon pipelines so translated blocks carry bubble metadata and outline widths
- update the Qt text rendering stack to honour bubble styles, drawing translucent rounded rectangles with shadows when present

## Testing
- `pytest` *(fails: ImportError: libGL.so.1 missing in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e53ae159b08330a05ace8958e267c1