### PR TITLE
Add auto color engine for text rendering

### DIFF
--- a/app/ui/canvas/image_viewer.py
+++ b/app/ui/canvas/image_viewer.py
@@ -387,18 +387,19 @@ class ImageViewer(QGraphicsView):
         # Create the TextBlockItem with the most up-to-date construction logic
         # Based on the load_state function which has the most complete setup
         item = TextBlockItem(
-            text=properties.text, 
+            text=properties.text,
             font_family=properties.font_family,
-            font_size=properties.font_size, 
+            font_size=properties.font_size,
             render_color=properties.text_color,
-            alignment=properties.alignment, 
+            alignment=properties.alignment,
             line_spacing=properties.line_spacing,
-            outline_color=properties.outline_color, 
+            outline_color=properties.outline_color,
             outline_width=properties.outline_width,
-            bold=properties.bold, 
-            italic=properties.italic, 
+            bold=properties.bold,
+            italic=properties.italic,
             underline=properties.underline,
             direction=properties.direction,
+            style_state=properties.style_state,
         )
         
         # Apply width if specified
@@ -422,6 +423,8 @@ class ImageViewer(QGraphicsView):
         
         # Update the item
         item.update()
+        if properties.style_state:
+            item.apply_style_state(properties.style_state)
 
         # Add to scene and track
         self._scene.addItem(item)

--- a/app/ui/canvas/text/text_item_properties.py
+++ b/app/ui/canvas/text/text_item_properties.py
@@ -3,6 +3,8 @@ from typing import Optional, List, Any
 from PySide6.QtGui import QColor
 from PySide6.QtCore import Qt
 
+from schemas.style_state import StyleState
+
 @dataclass
 class TextItemProperties:
     """Dataclass for TextBlockItem properties to reduce duplication in construction"""
@@ -31,6 +33,7 @@ class TextItemProperties:
     
     # Advanced properties
     selection_outlines: list = field(default_factory=list)
+    style_state: Optional[StyleState] = None
             
     @classmethod
     def from_dict(cls, data: dict) -> 'TextItemProperties':
@@ -84,7 +87,9 @@ class TextItemProperties:
         
         # Advanced
         props.selection_outlines = data.get('selection_outlines', [])
-        
+        if 'style_state' in data:
+            props.style_state = StyleState.from_dict(data.get('style_state'))
+
         return props
     
     @classmethod
@@ -120,7 +125,10 @@ class TextItemProperties:
         
         # Advanced properties
         props.selection_outlines = getattr(item, 'selection_outlines', []).copy()
-        
+        props.style_state = getattr(item, 'style_state', None)
+        if props.style_state is not None:
+            props.style_state = props.style_state.copy()
+
         return props
     
     def to_dict(self) -> dict:
@@ -145,4 +153,5 @@ class TextItemProperties:
             'width': self.width,
             'vertical': self.vertical,
             'selection_outlines': self.selection_outlines,
+            'style_state': self.style_state.to_dict() if isinstance(self.style_state, StyleState) else None,
         }

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -26,6 +26,7 @@ from .dayu_widgets.menu import MMenu
 from .canvas.image_viewer import ImageViewer
 from .settings.settings_page import SettingsPage
 from .list_view import PageListView
+from .style_panel import StylePanel
 
 
 current_file_dir = os.path.dirname(os.path.abspath(__file__))
@@ -520,10 +521,12 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
 
         rendering_divider_top = MDivider()
         rendering_divider_bottom = MDivider()
+        self.style_panel = StylePanel(self)
         text_render_layout.addWidget(rendering_divider_top)
         text_render_layout.addLayout(font_settings_layout)
         text_render_layout.addLayout(main_text_settings_layout)
         text_render_layout.addLayout(outline_settings_layout)
+        text_render_layout.addWidget(self.style_panel)
         text_render_layout.addWidget(rendering_divider_bottom)
 
         # Tools Layout
@@ -817,6 +820,8 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
         # Check if font_input is a file path
         if os.path.splitext(font_input)[1].lower() in [".ttf", ".ttc", ".otf", ".woff", ".woff2"]:
             QFontDatabase.addApplicationFont(font_input)
+            if hasattr(self, "style_panel") and self.style_panel:
+                self.style_panel.set_available_fonts(QFontDatabase().families())
 
     def get_color(self):
         default_color = QtGui.QColor('#000000')

--- a/app/ui/style_panel.py
+++ b/app/ui/style_panel.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+from PySide6 import QtWidgets
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QColor, QFontDatabase
+
+from schemas.style_state import StyleState
+
+
+class _ColorSwatchButton(QtWidgets.QPushButton):
+    colorChanged = Signal(QColor)
+
+    def __init__(self, label: str, parent: Optional[QtWidgets.QWidget] = None):
+        super().__init__(label, parent)
+        self._color = QColor(255, 255, 255)
+        self.setCursor(Qt.PointingHandCursor)
+        self.setFixedHeight(28)
+        self.clicked.connect(self._on_clicked)
+        self._update_style()
+
+    def _update_style(self) -> None:
+        self.setStyleSheet(
+            "QPushButton {"
+            "border: 1px solid rgba(0,0,0,80);"
+            "border-radius: 8px;"
+            f"background-color: {self._color.name()};"
+            "padding: 4px 10px;"
+            "text-align: left;"
+            "}"
+        )
+
+    def color(self) -> QColor:
+        return QColor(self._color)
+
+    def setColor(self, color: QColor) -> None:
+        if not color.isValid():
+            return
+        self._color = QColor(color)
+        self._update_style()
+
+    def _on_clicked(self) -> None:
+        dialog = QtWidgets.QColorDialog(self._color, self)
+        dialog.setOption(QtWidgets.QColorDialog.ShowAlphaChannel, False)
+        if dialog.exec():
+            chosen = dialog.currentColor()
+            if chosen.isValid():
+                self.setColor(chosen)
+                self.colorChanged.emit(chosen)
+
+
+class StylePanel(QtWidgets.QFrame):
+    """Compact Torii-inspired style editor for the active text item."""
+
+    styleChanged = Signal(StyleState)
+    reanalyseRequested = Signal()
+    fontChanged = Signal(str)
+    fontSizeChanged = Signal(int)
+    alignmentChanged = Signal(str)
+
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
+        super().__init__(parent)
+        self.setObjectName("toriiStylePanel")
+        self.setFrameShape(QtWidgets.QFrame.StyledPanel)
+        self.setFrameShadow(QtWidgets.QFrame.Raised)
+        self.setStyleSheet(
+            "#toriiStylePanel {"
+            "background: rgba(250, 250, 252, 235);"
+            "border-radius: 16px;"
+            "border: 1px solid rgba(0,0,0,40);"
+            "}"
+        )
+
+        self._style = StyleState()
+        self._blocked = False
+
+        main_layout = QtWidgets.QVBoxLayout(self)
+        main_layout.setContentsMargins(16, 16, 16, 16)
+        main_layout.setSpacing(10)
+
+        header_row = QtWidgets.QHBoxLayout()
+        header_label = QtWidgets.QLabel("Style")
+        header_label.setStyleSheet("font-weight: 600; letter-spacing: 0.8px;")
+        header_row.addWidget(header_label)
+        header_row.addStretch()
+        self.auto_color_toggle = QtWidgets.QCheckBox("Auto color")
+        self.auto_color_toggle.setChecked(True)
+        header_row.addWidget(self.auto_color_toggle)
+        self.reanalyse_btn = QtWidgets.QPushButton("Re-analyse")
+        self.reanalyse_btn.setCursor(Qt.PointingHandCursor)
+        header_row.addWidget(self.reanalyse_btn)
+        main_layout.addLayout(header_row)
+
+        font_row = QtWidgets.QHBoxLayout()
+        self.font_combo = QtWidgets.QFontComboBox()
+        self.font_combo.setMinimumWidth(160)
+        font_row.addWidget(self.font_combo)
+        self.font_size_spin = QtWidgets.QSpinBox()
+        self.font_size_spin.setRange(6, 120)
+        self.font_size_spin.setSuffix(" pt")
+        self.font_size_spin.setValue(32)
+        font_row.addWidget(self.font_size_spin)
+        main_layout.addLayout(font_row)
+
+        align_row = QtWidgets.QHBoxLayout()
+        self.align_group = QtWidgets.QButtonGroup(self)
+        for name, text in (("left", "L"), ("center", "C"), ("right", "R"), ("justify", "J")):
+            btn = QtWidgets.QToolButton()
+            btn.setText(text)
+            btn.setCheckable(True)
+            btn.setAutoRaise(True)
+            btn.setFixedSize(28, 28)
+            btn.setProperty("alignment", name)
+            self.align_group.addButton(btn)
+            align_row.addWidget(btn)
+        align_row.addStretch()
+        main_layout.addLayout(align_row)
+
+        color_row = QtWidgets.QHBoxLayout()
+        self.text_color_btn = _ColorSwatchButton("Text")
+        self.stroke_color_btn = _ColorSwatchButton("Stroke")
+        self.bg_color_btn = _ColorSwatchButton("Background")
+        color_row.addWidget(self.text_color_btn)
+        color_row.addWidget(self.stroke_color_btn)
+        color_row.addWidget(self.bg_color_btn)
+        main_layout.addLayout(color_row)
+
+        stroke_row = QtWidgets.QHBoxLayout()
+        self.stroke_slider = QtWidgets.QSlider(Qt.Horizontal)
+        self.stroke_slider.setRange(0, 12)
+        self.stroke_slider.setValue(0)
+        self.stroke_label = QtWidgets.QLabel("Stroke 0 px")
+        stroke_row.addWidget(self.stroke_label)
+        stroke_row.addWidget(self.stroke_slider)
+        main_layout.addLayout(stroke_row)
+
+        bg_opts_row = QtWidgets.QHBoxLayout()
+        self.bg_toggle = QtWidgets.QCheckBox("Background")
+        self.border_toggle = QtWidgets.QCheckBox("Border")
+        bg_opts_row.addWidget(self.bg_toggle)
+        bg_opts_row.addWidget(self.border_toggle)
+        bg_opts_row.addStretch()
+        main_layout.addLayout(bg_opts_row)
+
+        alpha_row = QtWidgets.QHBoxLayout()
+        self.bg_alpha_slider = QtWidgets.QSlider(Qt.Horizontal)
+        self.bg_alpha_slider.setRange(0, 255)
+        self.bg_alpha_slider.setValue(0)
+        self.bg_alpha_label = QtWidgets.QLabel("Alpha 0")
+        alpha_row.addWidget(self.bg_alpha_label)
+        alpha_row.addWidget(self.bg_alpha_slider)
+        main_layout.addLayout(alpha_row)
+
+        radius_row = QtWidgets.QHBoxLayout()
+        self.radius_slider = QtWidgets.QSlider(Qt.Horizontal)
+        self.radius_slider.setRange(0, 60)
+        self.radius_slider.setValue(0)
+        self.radius_label = QtWidgets.QLabel("Radius 0 px")
+        radius_row.addWidget(self.radius_label)
+        radius_row.addWidget(self.radius_slider)
+        main_layout.addLayout(radius_row)
+
+        padding_row = QtWidgets.QHBoxLayout()
+        self.padding_slider = QtWidgets.QSlider(Qt.Horizontal)
+        self.padding_slider.setRange(0, 60)
+        self.padding_slider.setValue(0)
+        self.padding_label = QtWidgets.QLabel("Padding 0 px")
+        padding_row.addWidget(self.padding_label)
+        padding_row.addWidget(self.padding_slider)
+        main_layout.addLayout(padding_row)
+
+        self._connect_signals()
+        self._refresh_enabled_state()
+        self.set_available_fonts(QFontDatabase().families())
+
+    # ------------------------------------------------------------------
+    # Setup helpers
+    def _connect_signals(self) -> None:
+        self.font_combo.currentFontChanged.connect(self._on_font_changed)
+        self.font_size_spin.valueChanged.connect(self._on_font_size_changed)
+        for btn in self.align_group.buttons():
+            btn.toggled.connect(self._handle_alignment_button)
+
+        self.text_color_btn.colorChanged.connect(self._on_text_color_changed)
+        self.stroke_color_btn.colorChanged.connect(self._on_stroke_color_changed)
+        self.bg_color_btn.colorChanged.connect(self._on_bg_color_changed)
+
+        self.auto_color_toggle.toggled.connect(self._on_auto_color_toggled)
+        self.stroke_slider.valueChanged.connect(self._on_stroke_size_changed)
+        self.bg_toggle.toggled.connect(self._on_bg_toggle)
+        self.border_toggle.toggled.connect(self._on_border_toggle)
+        self.bg_alpha_slider.valueChanged.connect(self._on_bg_alpha_changed)
+        self.radius_slider.valueChanged.connect(self._on_radius_changed)
+        self.padding_slider.valueChanged.connect(self._on_padding_changed)
+        self.reanalyse_btn.clicked.connect(self.reanalyseRequested.emit)
+
+    # Alignment buttons do not emit IDs by default; hook per-button toggle.
+    def _handle_alignment_button(self, checked: bool) -> None:
+        if not checked:
+            return
+        btn = self.sender()
+        if not isinstance(btn, QtWidgets.QToolButton):
+            return
+        alignment = btn.property("alignment") or "left"
+        self._style.text_align = alignment
+        self.alignmentChanged.emit(alignment)
+
+    def _on_font_size_changed(self, value: int) -> None:
+        if self._blocked:
+            return
+        self._style.font_size = value
+        self.fontSizeChanged.emit(value)
+
+    def _on_font_changed(self, font) -> None:
+        if self._blocked:
+            return
+        family = font.family()
+        self._style.font_family = family
+        self.fontChanged.emit(family)
+
+    def _on_auto_color_toggled(self, checked: bool) -> None:
+        if self._blocked:
+            return
+        self._style.auto_color = checked
+        self._refresh_enabled_state()
+        self._emit_style()
+
+    def _on_text_color_changed(self, color: QColor) -> None:
+        if self._blocked:
+            return
+        self._style.auto_color = False
+        self.auto_color_toggle.setChecked(False)
+        self._style.fill = (color.red(), color.green(), color.blue())
+        self._emit_style()
+
+    def _on_stroke_color_changed(self, color: QColor) -> None:
+        if self._blocked:
+            return
+        self._style.stroke = (color.red(), color.green(), color.blue())
+        self._style.stroke_enabled = True
+        if self.stroke_slider.value() == 0:
+            self.stroke_slider.setValue(max(1, int(round(self._style.font_size / 18 if self._style.font_size else 1))))
+        self._emit_style()
+
+    def _on_bg_color_changed(self, color: QColor) -> None:
+        if self._blocked:
+            return
+        self._style.bg_color = (color.red(), color.green(), color.blue())
+        if not self.bg_toggle.isChecked():
+            self.bg_toggle.setChecked(True)
+        self._emit_style()
+
+    def _on_stroke_size_changed(self, value: int) -> None:
+        self.stroke_label.setText(f"Stroke {value} px")
+        if self._blocked:
+            return
+        self._style.stroke_size = value if value > 0 else None
+        self._style.stroke_enabled = value > 0 and self._style.stroke is not None
+        self._emit_style()
+
+    def _on_bg_toggle(self, checked: bool) -> None:
+        if self._blocked:
+            return
+        self._style.bg_enabled = checked
+        self._refresh_enabled_state()
+        self._emit_style()
+
+    def _on_border_toggle(self, checked: bool) -> None:
+        if self._blocked:
+            return
+        self._style.border_enabled = checked
+        self._refresh_enabled_state()
+        self._emit_style()
+
+    def _on_bg_alpha_changed(self, value: int) -> None:
+        self.bg_alpha_label.setText(f"Alpha {value}")
+        if self._blocked:
+            return
+        self._style.bg_alpha = value
+        self._emit_style()
+
+    def _on_radius_changed(self, value: int) -> None:
+        self.radius_label.setText(f"Radius {value} px")
+        if self._blocked:
+            return
+        self._style.border_radius = value
+        self._emit_style()
+
+    def _on_padding_changed(self, value: int) -> None:
+        self.padding_label.setText(f"Padding {value} px")
+        if self._blocked:
+            return
+        self._style.border_padding = value
+        self._emit_style()
+
+    def _emit_style(self) -> None:
+        self.styleChanged.emit(self._style.copy())
+
+    def _refresh_enabled_state(self) -> None:
+        manual_enabled = not self.auto_color_toggle.isChecked()
+        self.text_color_btn.setEnabled(manual_enabled)
+        self.stroke_color_btn.setEnabled(manual_enabled)
+        stroke_controls = manual_enabled or (self._style.stroke is not None)
+        self.stroke_slider.setEnabled(stroke_controls)
+        self.bg_color_btn.setEnabled(self.bg_toggle.isChecked())
+        alpha_enabled = self.bg_toggle.isChecked()
+        self.bg_alpha_slider.setEnabled(alpha_enabled)
+        self.padding_slider.setEnabled(alpha_enabled or self.border_toggle.isChecked())
+        self.radius_slider.setEnabled(alpha_enabled or self.border_toggle.isChecked())
+
+    # ------------------------------------------------------------------
+    # Public API
+    def set_available_fonts(self, families: Iterable[str]) -> None:
+        current = self.font_combo.currentFont().family()
+        self.font_combo.blockSignals(True)
+        self.font_combo.clear()
+        for family in families:
+            self.font_combo.addItem(family)
+        if current:
+            self.font_combo.setCurrentText(current)
+        self.font_combo.blockSignals(False)
+
+    def set_style(self, style: StyleState, font_family: str, font_size: int, alignment: str) -> None:
+        self._blocked = True
+        try:
+            self._style = style.copy()
+            self.auto_color_toggle.setChecked(self._style.auto_color)
+            if self._style.fill is not None:
+                self.text_color_btn.setColor(QColor(*self._style.fill))
+            if self._style.stroke is not None:
+                self.stroke_color_btn.setColor(QColor(*self._style.stroke))
+            if self._style.bg_color is not None:
+                self.bg_color_btn.setColor(QColor(*self._style.bg_color))
+            self.stroke_slider.setValue(int(self._style.stroke_size or 0))
+            self.stroke_label.setText(f"Stroke {int(self._style.stroke_size or 0)} px")
+            self.bg_toggle.setChecked(bool(self._style.bg_enabled))
+            self.border_toggle.setChecked(bool(self._style.border_enabled))
+            self.bg_alpha_slider.setValue(int(self._style.bg_alpha))
+            self.bg_alpha_label.setText(f"Alpha {int(self._style.bg_alpha)}")
+            self.radius_slider.setValue(int(self._style.border_radius))
+            self.radius_label.setText(f"Radius {int(self._style.border_radius)} px")
+            self.padding_slider.setValue(int(self._style.border_padding))
+            self.padding_label.setText(f"Padding {int(self._style.border_padding)} px")
+            self.font_combo.setCurrentText(font_family)
+            self.font_size_spin.setValue(max(6, int(font_size)))
+            self._select_alignment_button(alignment)
+        finally:
+            self._blocked = False
+        self._refresh_enabled_state()
+
+    def clear_style(self) -> None:
+        self._blocked = True
+        try:
+            self._style = StyleState()
+            self.auto_color_toggle.setChecked(True)
+            self.stroke_slider.setValue(0)
+            self.stroke_label.setText("Stroke 0 px")
+            self.bg_toggle.setChecked(False)
+            self.border_toggle.setChecked(False)
+            self.bg_alpha_slider.setValue(0)
+            self.bg_alpha_label.setText("Alpha 0")
+            self.radius_slider.setValue(0)
+            self.radius_label.setText("Radius 0 px")
+            self.padding_slider.setValue(0)
+            self.padding_label.setText("Padding 0 px")
+        finally:
+            self._blocked = False
+        self._refresh_enabled_state()
+
+    def _select_alignment_button(self, name: str) -> None:
+        mapping = {btn.property("alignment"): btn for btn in self.align_group.buttons()}
+        btn = mapping.get(name, mapping.get("left"))
+        if btn:
+            btn.setChecked(True)
+
+
+__all__ = ["StylePanel"]

--- a/modules/layout/__init__.py
+++ b/modules/layout/__init__.py
@@ -1,0 +1,5 @@
+"""Layout utilities for grouping text blocks."""
+
+from .grouping import TextGroup, group_text_blocks
+
+__all__ = ["TextGroup", "group_text_blocks"]

--- a/modules/layout/grouping.py
+++ b/modules/layout/grouping.py
@@ -1,0 +1,98 @@
+"""Utilities for grouping OCR text blocks into logical clusters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence, Tuple
+
+import numpy as np
+from shapely.geometry import Polygon, box
+from shapely.ops import unary_union
+
+from modules.utils.textblock import TextBlock
+
+
+@dataclass
+class TextGroup:
+    blocks: List[TextBlock]
+    polygon: np.ndarray
+    bbox: Tuple[int, int, int, int]
+
+
+def _block_polygon(block: TextBlock) -> Polygon:
+    if block.segm_pts is not None and len(block.segm_pts) >= 6:
+        pts = np.asarray(block.segm_pts, dtype=np.float32).reshape(-1, 2)
+        return Polygon(pts)
+    if block.xyxy is not None and len(block.xyxy) == 4:
+        x1, y1, x2, y2 = block.xyxy
+        return box(x1, y1, x2, y2)
+    raise ValueError("Block lacks sufficient geometry for grouping")
+
+
+def group_text_blocks(blocks: Sequence[TextBlock]) -> List[TextGroup]:
+    """Merge nearby blocks that share a bubble or overlapping area."""
+
+    if not blocks:
+        return []
+
+    remaining = list(blocks)
+    groups: List[TextGroup] = []
+
+    while remaining:
+        blk = remaining.pop(0)
+        current = [blk]
+        geom = _block_polygon(blk)
+        bubble_key = None
+        if getattr(blk, "bubble_xyxy", None) is not None:
+            bubble_key = tuple(int(v) for v in blk.bubble_xyxy)
+
+        matched = []
+        for other in remaining:
+            other_key = tuple(int(v) for v in other.bubble_xyxy) if getattr(other, "bubble_xyxy", None) is not None else None
+            should_merge = False
+            if bubble_key and other_key and bubble_key == other_key:
+                should_merge = True
+            else:
+                try:
+                    other_geom = _block_polygon(other)
+                except ValueError:
+                    continue
+                dilated = other_geom.buffer(max(other_geom.length * 0.02, 4.0))
+                if geom.buffer(max(geom.length * 0.02, 4.0)).intersects(dilated):
+                    should_merge = True
+            if should_merge:
+                matched.append(other)
+
+        for mt in matched:
+            remaining.remove(mt)
+            current.append(mt)
+
+        polygons = []
+        for blk_member in current:
+            try:
+                polygons.append(_block_polygon(blk_member))
+            except ValueError:
+                continue
+        if not polygons:
+            continue
+
+        merged = unary_union(polygons)
+        if merged.geom_type == "Polygon":
+            coords = np.array(merged.exterior.coords, dtype=np.float32)
+            minx, miny, maxx, maxy = merged.bounds
+        else:
+            coords = np.array(merged.convex_hull.exterior.coords, dtype=np.float32)
+            minx, miny, maxx, maxy = merged.convex_hull.bounds
+
+        groups.append(
+            TextGroup(
+                blocks=current,
+                polygon=coords,
+                bbox=(int(minx), int(miny), int(np.ceil(maxx)), int(np.ceil(maxy))),
+            )
+        )
+
+    return groups
+
+
+__all__ = ["TextGroup", "group_text_blocks"]

--- a/modules/rendering/__init__.py
+++ b/modules/rendering/__init__.py
@@ -1,1 +1,7 @@
+"""Rendering utilities for translated text."""
 
+from .auto_style import AutoStyleEngine
+from .decisions import AutoStyleConfig
+from .color_analysis import ColorAnalysis
+
+__all__ = ["AutoStyleEngine", "AutoStyleConfig", "ColorAnalysis"]

--- a/modules/rendering/auto_style.py
+++ b/modules/rendering/auto_style.py
@@ -1,0 +1,48 @@
+"""High level interface for Torii-style auto text rendering decisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+import numpy as np
+
+from modules.layout.grouping import TextGroup, group_text_blocks
+from schemas.style_state import StyleState
+
+from .color_analysis import ColorAnalysis, analyse_group_colors
+from .decisions import AutoStyleConfig, decide_style
+
+
+@dataclass
+class AutoStyleResult:
+    group: TextGroup
+    analysis: Optional[ColorAnalysis]
+    style: StyleState
+
+
+class AutoStyleEngine:
+    """Analyse text groups and produce rendering styles."""
+
+    def __init__(self, config: Optional[AutoStyleConfig] = None, ring_radius: int = 6):
+        self.config = config or AutoStyleConfig()
+        self.ring_radius = ring_radius
+
+    def analyse_image(self, image: np.ndarray, blocks: Iterable, base_state: StyleState) -> List[AutoStyleResult]:
+        groups = group_text_blocks(list(blocks))
+        results: List[AutoStyleResult] = []
+        for group in groups:
+            analysis = analyse_group_colors(image, group, ring_radius=self.ring_radius)
+            style = decide_style(analysis, base_state, self.config)
+            results.append(AutoStyleResult(group=group, analysis=analysis, style=style))
+        return results
+
+    def style_for_block(self, image: np.ndarray, block, base_state: StyleState) -> StyleState:
+        groups = group_text_blocks([block])
+        if not groups:
+            return decide_style(None, base_state, self.config)
+        analysis = analyse_group_colors(image, groups[0], ring_radius=self.ring_radius)
+        return decide_style(analysis, base_state, self.config)
+
+
+__all__ = ["AutoStyleEngine", "AutoStyleResult"]

--- a/modules/rendering/color_analysis.py
+++ b/modules/rendering/color_analysis.py
@@ -1,0 +1,133 @@
+"""Colour sampling routines for Torii-style auto rendering."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Sequence, Tuple
+
+import mahotas as mh
+import numpy as np
+
+from modules.layout.grouping import TextGroup
+from modules.utils.masks import dilate, erode, polygon_to_mask, ring
+from modules.utils.wcag import relative_luminance
+
+ColorTuple = Tuple[int, int, int]
+
+
+@dataclass
+class ColorAnalysis:
+    fill_rgb: Optional[ColorTuple]
+    stroke_rgb: Optional[ColorTuple]
+    background_rgb: Optional[ColorTuple]
+    fill_luminance: Optional[float]
+    stroke_luminance: Optional[float]
+    background_luminance: Optional[float]
+    plain_white: bool
+    plain_black: bool
+    core_pixel_count: int
+    stroke_pixel_count: int
+    background_pixel_count: int
+
+
+def _median_rgb(values: np.ndarray) -> Optional[ColorTuple]:
+    if values.size == 0:
+        return None
+    reshaped = values.reshape(-1, values.shape[-1])
+    med = np.median(reshaped, axis=0)
+    return tuple(int(round(v)) for v in med)
+
+
+def _auto_threshold(gray: np.ndarray) -> float:
+    flat = gray.reshape(-1)
+    if flat.size == 0:
+        return 0.0
+    return float(mh.thresholding.otsu(flat.astype(np.uint8)))
+
+
+def _choose_text_mask(gray: np.ndarray, polygon_mask: np.ndarray) -> np.ndarray:
+    interior_pixels = gray[polygon_mask]
+    if interior_pixels.size == 0:
+        return np.zeros_like(gray, dtype=bool)
+    threshold = _auto_threshold(interior_pixels)
+    darker = np.logical_and(gray <= threshold, polygon_mask)
+    lighter = np.logical_and(gray >= threshold, polygon_mask)
+    return darker if darker.sum() >= lighter.sum() else lighter
+
+
+def analyse_group_colors(
+    image: np.ndarray,
+    group: TextGroup,
+    ring_radius: int = 6,
+    min_core_pixels: int = 50,
+) -> Optional[ColorAnalysis]:
+    if image is None or image.size == 0:
+        return None
+
+    minx, miny, maxx, maxy = group.bbox
+    pad = max(ring_radius + 2, 4)
+    h, w = image.shape[:2]
+    x1 = max(0, minx - pad)
+    y1 = max(0, miny - pad)
+    x2 = min(w, maxx + pad)
+    y2 = min(h, maxy + pad)
+    if x2 <= x1 or y2 <= y1:
+        return None
+
+    patch = image[y1:y2, x1:x2]
+    poly = np.asarray(group.polygon, dtype=np.float32)
+    if poly.size == 0:
+        return None
+    local_poly = [(float(x) - x1, float(y) - y1) for x, y in poly]
+    mask = polygon_to_mask((patch.shape[0], patch.shape[1]), local_poly)
+    if not mask.any():
+        return None
+
+    gray = np.dot(patch[..., :3], [0.299, 0.587, 0.114])
+    text_mask = _choose_text_mask(gray, mask)
+
+    core = erode(text_mask, 1)
+    if core.sum() < min_core_pixels:
+        core = text_mask
+
+    stroke_candidates = np.logical_and(dilate(core, 1), mask)
+    stroke_ring = np.logical_and(stroke_candidates, np.logical_not(core))
+    background_ring = ring(mask, 0, ring_radius)
+    if background_ring.sum() < min_core_pixels:
+        background_ring = ring(mask, 1, max(ring_radius, 3))
+
+    fill_rgb = _median_rgb(patch[core])
+    stroke_rgb = _median_rgb(patch[stroke_ring]) if stroke_ring.any() else None
+    bg_rgb = _median_rgb(patch[background_ring]) if background_ring.any() else None
+
+    fill_lum = relative_luminance(fill_rgb) if fill_rgb else None
+    stroke_lum = relative_luminance(stroke_rgb) if stroke_rgb else None
+    bg_lum = relative_luminance(bg_rgb) if bg_rgb else None
+
+    plain_white = False
+    plain_black = False
+    if bg_rgb is not None:
+        bg_pixels = patch[background_ring]
+        if bg_pixels.size:
+            bg_float = bg_pixels.reshape(-1, 3).astype(np.float32) / 255.0
+            mean = float(np.mean(bg_float))
+            var = float(np.var(bg_float))
+            plain_white = mean > 0.94 and var < 0.002
+            plain_black = mean < 0.06 and var < 0.002
+
+    return ColorAnalysis(
+        fill_rgb=fill_rgb,
+        stroke_rgb=stroke_rgb,
+        background_rgb=bg_rgb,
+        fill_luminance=fill_lum,
+        stroke_luminance=stroke_lum,
+        background_luminance=bg_lum,
+        plain_white=plain_white,
+        plain_black=plain_black,
+        core_pixel_count=int(core.sum()),
+        stroke_pixel_count=int(stroke_ring.sum()),
+        background_pixel_count=int(background_ring.sum()),
+    )
+
+
+__all__ = ["ColorAnalysis", "analyse_group_colors"]

--- a/modules/rendering/decisions.py
+++ b/modules/rendering/decisions.py
@@ -1,0 +1,116 @@
+"""Decision rules for converting colour analysis into rendering styles."""
+
+from __future__ import annotations
+
+import colorsys
+from dataclasses import dataclass
+from typing import Optional
+
+from schemas.style_state import StyleState
+from .color_analysis import ColorAnalysis
+from modules.utils.wcag import (
+    ensure_contrast,
+    normalize_rgb,
+    pick_higher_contrast,
+    relative_luminance,
+)
+
+
+@dataclass
+class AutoStyleConfig:
+    target_contrast: float = 4.5
+    stroke_max_size: int = 6
+    stroke_factor: float = 18.0
+    brighten_amount: float = 0.08
+    stroke_min_distance: float = 18.0
+    plain_white_stroke: bool = True
+    plain_black_stroke: bool = True
+
+
+def _distance(rgb_a, rgb_b) -> float:
+    ax, ay, az = rgb_a
+    bx, by, bz = rgb_b
+    return ((ax - bx) ** 2 + (ay - by) ** 2 + (az - bz) ** 2) ** 0.5
+
+
+def _brighten(rgb, amount: float) -> tuple[int, int, int]:
+    r, g, b = [v / 255.0 for v in rgb]
+    h, l, s = colorsys.rgb_to_hls(r, g, b)
+    l = min(1.0, l + amount)
+    r2, g2, b2 = colorsys.hls_to_rgb(h, l, s)
+    return tuple(int(round(v * 255.0)) for v in (r2, g2, b2))
+
+
+def _synth_stroke(fill_rgb, background_rgb=None):
+    if background_rgb is not None:
+        return pick_higher_contrast((0, 0, 0), (255, 255, 255), fill_rgb)
+    fill_lum = relative_luminance(fill_rgb)
+    return (0, 0, 0) if fill_lum > 0.5 else (255, 255, 255)
+
+
+def decide_style(
+    analysis: Optional[ColorAnalysis],
+    base_state: StyleState,
+    config: Optional[AutoStyleConfig] = None,
+) -> StyleState:
+    config = config or AutoStyleConfig()
+    state = base_state.copy()
+
+    if not state.auto_color or analysis is None:
+        if state.stroke is not None:
+            state.stroke_enabled = True
+        return state
+
+    state.stroke_enabled = False
+
+    fill_rgb = analysis.fill_rgb
+    stroke_rgb = analysis.stroke_rgb
+    background_rgb = analysis.background_rgb
+    plain_background = analysis.plain_white or analysis.plain_black
+
+    if analysis.plain_white:
+        fill_rgb = (0, 0, 0)
+        if state.no_stroke_on_plain:
+            stroke_rgb = None
+        elif config.plain_white_stroke:
+            stroke_rgb = (255, 255, 255)
+    elif analysis.plain_black:
+        fill_rgb = (255, 255, 255)
+        if state.no_stroke_on_plain:
+            stroke_rgb = None
+        elif config.plain_black_stroke:
+            stroke_rgb = (0, 0, 0)
+    else:
+        if fill_rgb is None and background_rgb is not None:
+            fill_rgb = pick_higher_contrast((0, 0, 0), (255, 255, 255), background_rgb)
+        if fill_rgb is None:
+            fill_rgb = (0, 0, 0)
+        else:
+            fill_rgb = _brighten(fill_rgb, config.brighten_amount)
+
+    if background_rgb is not None and fill_rgb is not None:
+        enforced = ensure_contrast(fill_rgb, background_rgb, config.target_contrast)
+        if enforced != fill_rgb:
+            fill_rgb = enforced
+            if not (plain_background and state.no_stroke_on_plain):
+                stroke_rgb = _synth_stroke(fill_rgb, background_rgb)
+
+    if fill_rgb is not None and stroke_rgb is not None:
+        if _distance(fill_rgb, stroke_rgb) < config.stroke_min_distance:
+            stroke_rgb = _synth_stroke(fill_rgb, background_rgb)
+
+    if stroke_rgb is None and background_rgb is not None and not (plain_background and state.no_stroke_on_plain):
+        stroke_rgb = _synth_stroke(fill_rgb, background_rgb)
+
+    state.fill = normalize_rgb(fill_rgb) if fill_rgb is not None else None
+    state.stroke = normalize_rgb(stroke_rgb) if stroke_rgb is not None else None
+    state.stroke_enabled = state.stroke is not None
+
+    if state.stroke_size is None:
+        auto_size = max(1, min(int(round(state.font_size / config.stroke_factor)), config.stroke_max_size))
+        state.stroke_size = auto_size
+
+    return state
+
+
+__all__ = ["AutoStyleConfig", "decide_style"]

--- a/modules/utils/masks.py
+++ b/modules/utils/masks.py
@@ -1,0 +1,73 @@
+"""Helpers for constructing and manipulating binary masks."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence, Tuple
+
+import mahotas as mh
+import numpy as np
+from PIL import Image, ImageDraw
+
+ArrayLike = np.ndarray
+
+
+def polygon_to_mask(size: Tuple[int, int], polygon: Sequence[Tuple[float, float]]) -> ArrayLike:
+    """Rasterise a polygon into a boolean mask."""
+
+    height, width = size
+    if height <= 0 or width <= 0:
+        return np.zeros((0, 0), dtype=bool)
+
+    img = Image.new("L", (width, height), 0)
+    draw = ImageDraw.Draw(img)
+    if polygon:
+        draw.polygon(list(polygon), outline=1, fill=1)
+    mask = np.array(img, dtype=bool)
+    return mask
+
+
+def dilate(mask: ArrayLike, radius: int = 1) -> ArrayLike:
+    if mask.size == 0 or radius <= 0:
+        return mask.astype(bool)
+    structure = np.ones((radius * 2 + 1, radius * 2 + 1), dtype=bool)
+    return mh.dilate(mask.astype(bool), structure)
+
+
+def erode(mask: ArrayLike, radius: int = 1) -> ArrayLike:
+    if mask.size == 0 or radius <= 0:
+        return mask.astype(bool)
+    structure = np.ones((radius * 2 + 1, radius * 2 + 1), dtype=bool)
+    return mh.erode(mask.astype(bool), structure)
+
+
+def ring(mask: ArrayLike, inner_radius: int, outer_radius: int) -> ArrayLike:
+    """Return the ring between two dilation radii."""
+
+    if inner_radius < 0:
+        raise ValueError("inner_radius must be non-negative")
+    if outer_radius <= inner_radius:
+        raise ValueError("outer_radius must be greater than inner_radius")
+
+    inner = dilate(mask, inner_radius) if inner_radius > 0 else mask.astype(bool)
+    outer = dilate(mask, outer_radius)
+    return np.logical_and(outer, np.logical_not(inner))
+
+
+def bounds_from_polygon(polygon: Iterable[Tuple[float, float]]) -> Tuple[int, int, int, int]:
+    """Compute axis-aligned bounds covering the polygon."""
+
+    xs, ys = zip(*polygon) if polygon else ((0,), (0,))
+    x1 = int(np.floor(min(xs)))
+    y1 = int(np.floor(min(ys)))
+    x2 = int(np.ceil(max(xs)))
+    y2 = int(np.ceil(max(ys)))
+    return x1, y1, x2, y2
+
+
+__all__ = [
+    "polygon_to_mask",
+    "dilate",
+    "erode",
+    "ring",
+    "bounds_from_polygon",
+]

--- a/modules/utils/textblock.py
+++ b/modules/utils/textblock.py
@@ -4,6 +4,7 @@ import copy
 from PIL import Image, ImageDraw
 from collections import defaultdict, deque
 from ..detection.utils.text_lines import group_items_into_lines
+from schemas.style_state import StyleState
 
 class TextBlock(object):
     """
@@ -56,6 +57,11 @@ class TextBlock(object):
         self.max_font_size = max_font_size
         self.font_color = font_color
         self.outline_color = outline_color
+        style_state = kwargs.get("style_state")
+        if isinstance(style_state, StyleState):
+            self.style_state: StyleState | None = style_state
+        else:
+            self.style_state = None
 
     @property
     def xywh(self):
@@ -106,7 +112,8 @@ class TextBlock(object):
         new_block.max_font_size = self.max_font_size
         new_block.font_color = self.font_color
         new_block.outline_color = self.outline_color
-        
+        new_block.style_state = self.style_state.copy() if self.style_state else None
+
         return new_block
 
 def sort_blk_list(blk_list: List[TextBlock], right_to_left=True) -> List[TextBlock]:

--- a/modules/utils/wcag.py
+++ b/modules/utils/wcag.py
@@ -1,0 +1,81 @@
+"""Utilities for WCAG contrast and luminance calculations."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence, Tuple
+import numpy as np
+
+ColorLike = Sequence[float]
+
+
+def _to_linear_rgb(rgb: ColorLike) -> np.ndarray:
+    arr = np.asarray(rgb, dtype=np.float32)
+    if arr.ndim == 0:
+        raise ValueError("RGB colour must be a sequence of length 3")
+    if arr.shape[-1] != 3:
+        raise ValueError("RGB colour must have exactly three channels")
+    if arr.max() > 1.0:
+        arr = arr / 255.0
+    return np.clip(arr, 0.0, 1.0)
+
+
+def relative_luminance(rgb: ColorLike) -> float:
+    """Compute the WCAG relative luminance of a colour."""
+
+    linear = _to_linear_rgb(rgb)
+    coeffs = np.array([0.2126, 0.7152, 0.0722], dtype=np.float32)
+    lum = float(np.dot(linear, coeffs))
+    return lum
+
+
+def contrast_ratio(color_a: ColorLike, color_b: ColorLike) -> float:
+    """Return the WCAG contrast ratio between two colours."""
+
+    lum1 = relative_luminance(color_a)
+    lum2 = relative_luminance(color_b)
+    lighter = max(lum1, lum2)
+    darker = min(lum1, lum2)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def pick_higher_contrast(candidate_a: ColorLike, candidate_b: ColorLike, background: ColorLike) -> Tuple[int, int, int]:
+    """Return the candidate with higher contrast against the background."""
+
+    ratio_a = contrast_ratio(candidate_a, background)
+    ratio_b = contrast_ratio(candidate_b, background)
+    chosen = candidate_a if ratio_a >= ratio_b else candidate_b
+    arr = np.asarray(chosen, dtype=np.float32)
+    if arr.max() <= 1.0:
+        arr = arr * 255.0
+    return tuple(int(round(v)) for v in arr)
+
+
+def ensure_contrast(fill_rgb: ColorLike, background_rgb: ColorLike, target: float = 4.5) -> Tuple[int, int, int]:
+    """Return a colour that meets the target contrast against the background."""
+
+    fill = _to_linear_rgb(fill_rgb)
+    background = _to_linear_rgb(background_rgb)
+    current = contrast_ratio(fill, background)
+    if current >= target:
+        arr = fill
+    else:
+        # Snap to whichever extreme (black/white) offers better contrast.
+        arr = _to_linear_rgb([0.0, 0.0, 0.0]) if contrast_ratio([0, 0, 0], background) >= contrast_ratio([1, 1, 1], background) else _to_linear_rgb([255, 255, 255])
+    return tuple(int(round(v * 255.0)) for v in arr)
+
+
+def normalize_rgb(rgb: Iterable[float]) -> Tuple[int, int, int]:
+    arr = np.asarray(tuple(rgb), dtype=np.float32)
+    if arr.max() <= 1.0:
+        arr *= 255.0
+    arr = np.clip(arr, 0.0, 255.0)
+    return tuple(int(round(v)) for v in arr)
+
+
+__all__ = [
+    "contrast_ratio",
+    "relative_luminance",
+    "ensure_contrast",
+    "pick_higher_contrast",
+    "normalize_rgb",
+]

--- a/pipeline/batch_processor.py
+++ b/pipeline/batch_processor.py
@@ -390,6 +390,8 @@ class BatchProcessor:
                     logger.exception("Auto style inference failed for block")
                     style_state = base_style
 
+                blk.style_state = style_state.copy()
+
                 if style_state.fill is not None:
                     text_color = QColor(*style_state.fill)
                     blk.font_color = _rgb_to_hex(style_state.fill)
@@ -446,6 +448,7 @@ class BatchProcessor:
                         outline_width_value,
                         OutlineType.Full_Document)
                     ] if outline_enabled else [],
+                    style_state=style_state.copy() if isinstance(style_state, StyleState) else None,
                 )
                 text_items_state.append(text_props.to_dict())
 

--- a/pipeline/webtoon_batch_processor.py
+++ b/pipeline/webtoon_batch_processor.py
@@ -849,6 +849,8 @@ class WebtoonBatchProcessor:
                 logger.exception("Auto style inference failed for virtual page %s", vpage.virtual_id)
                 style_state = base_style
 
+            blk_virtual.style_state = style_state.copy()
+
             if style_state.fill is not None:
                 text_color = QColor(*style_state.fill)
                 blk_virtual.font_color = _rgb_to_hex(style_state.fill)
@@ -887,6 +889,7 @@ class WebtoonBatchProcessor:
             render_blk.translation = translation
             render_blk.font_color = blk_virtual.font_color
             render_blk.outline_color = blk_virtual.outline_color
+            render_blk.style_state = style_state.copy()
 
             if should_emit_live:
                 self.main_page.blk_rendered.emit(translation, font_size, render_blk)
@@ -923,6 +926,7 @@ class WebtoonBatchProcessor:
                         OutlineType.Full_Document
                     )
                 ] if outline_enabled else [],
+                style_state=style_state.copy() if isinstance(style_state, StyleState) else None,
             )
             text_items_state.append(text_props.to_dict())
             page_blk_list.append(render_blk)

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,0 +1,5 @@
+"""Schema definitions used across the application."""
+
+from .style_state import StyleState
+
+__all__ = ["StyleState"]

--- a/schemas/style_state.py
+++ b/schemas/style_state.py
@@ -1,0 +1,63 @@
+"""Data structures representing rendering style options for text blocks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+ColorTuple = Tuple[int, int, int]
+
+
+@dataclass
+class StyleState:
+    """User and engine controlled styling for a translated text block."""
+
+    font_family: str = "WildWords"
+    font_size: int = 32
+    text_align: str = "left"
+    auto_color: bool = True
+    fill: Optional[ColorTuple] = None
+    stroke: Optional[ColorTuple] = None
+    stroke_size: Optional[int] = None
+    stroke_enabled: bool = False
+    bg_enabled: bool = False
+    bg_color: ColorTuple = (255, 255, 255)
+    bg_alpha: int = 0
+    border_enabled: bool = False
+    border_radius: int = 0
+    border_padding: int = 0
+    font_weight: str = "normal"
+    italic: bool = False
+    underline: bool = False
+    no_stroke_on_plain: bool = True
+    analysis_cache_key: Optional[str] = None
+    metadata: dict = field(default_factory=dict)
+
+    def copy(self) -> "StyleState":
+        """Return a shallow copy of the state suitable for per-block tweaks."""
+
+        return StyleState(
+            font_family=self.font_family,
+            font_size=self.font_size,
+            text_align=self.text_align,
+            auto_color=self.auto_color,
+            fill=None if self.fill is None else tuple(self.fill),
+            stroke=None if self.stroke is None else tuple(self.stroke),
+            stroke_size=self.stroke_size,
+            stroke_enabled=self.stroke_enabled,
+            bg_enabled=self.bg_enabled,
+            bg_color=tuple(self.bg_color),
+            bg_alpha=self.bg_alpha,
+            border_enabled=self.border_enabled,
+            border_radius=self.border_radius,
+            border_padding=self.border_padding,
+            font_weight=self.font_weight,
+            italic=self.italic,
+            underline=self.underline,
+            no_stroke_on_plain=self.no_stroke_on_plain,
+            analysis_cache_key=self.analysis_cache_key,
+            metadata=dict(self.metadata),
+        )
+
+
+__all__ = ["StyleState", "ColorTuple"]

--- a/schemas/style_state.py
+++ b/schemas/style_state.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Optional, Tuple
 
 ColorTuple = Tuple[int, int, int]
@@ -58,6 +58,32 @@ class StyleState:
             analysis_cache_key=self.analysis_cache_key,
             metadata=dict(self.metadata),
         )
+
+    def to_dict(self) -> dict:
+        """Serialise the style state into basic Python types."""
+
+        data = asdict(self)
+        # Dataclasses converts tuples to lists; convert back for stability.
+        if data.get("fill") is not None:
+            data["fill"] = tuple(data["fill"])
+        if data.get("stroke") is not None:
+            data["stroke"] = tuple(data["stroke"])
+        if data.get("bg_color") is not None:
+            data["bg_color"] = tuple(data["bg_color"])
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Optional[dict]) -> "StyleState":
+        """Recreate a :class:`StyleState` from serialised data."""
+
+        if not data:
+            return cls()
+
+        kwargs = dict(data)
+        for key in ("fill", "stroke", "bg_color"):
+            if key in kwargs and kwargs[key] is not None:
+                kwargs[key] = tuple(kwargs[key])
+        return cls(**kwargs)
 
 
 __all__ = ["StyleState", "ColorTuple"]

--- a/tests/test_auto_style.py
+++ b/tests/test_auto_style.py
@@ -1,0 +1,46 @@
+from schemas.style_state import StyleState
+from modules.rendering.decisions import decide_style, AutoStyleConfig
+from modules.rendering.color_analysis import ColorAnalysis
+
+
+def _analysis(**kwargs):
+    defaults = dict(
+        fill_rgb=(50, 50, 50),
+        stroke_rgb=None,
+        background_rgb=(240, 240, 240),
+        fill_luminance=None,
+        stroke_luminance=None,
+        background_luminance=None,
+        plain_white=False,
+        plain_black=False,
+        core_pixel_count=200,
+        stroke_pixel_count=120,
+        background_pixel_count=400,
+    )
+    defaults.update(kwargs)
+    return ColorAnalysis(**defaults)
+
+
+def test_plain_white_prefers_black_text_without_stroke():
+    base_state = StyleState(font_family="Test", font_size=24, auto_color=True)
+    analysis = _analysis(plain_white=True, background_rgb=(250, 250, 250))
+    result = decide_style(analysis, base_state)
+    assert result.fill == (0, 0, 0)
+    assert result.stroke is None
+
+
+def test_plain_black_prefers_white_text():
+    base_state = StyleState(font_family="Test", font_size=24, auto_color=True)
+    analysis = _analysis(plain_black=True, background_rgb=(5, 5, 5))
+    result = decide_style(analysis, base_state)
+    assert result.fill == (255, 255, 255)
+    assert result.stroke in {None, (0, 0, 0)}
+
+
+def test_contrast_enforced_when_background_close():
+    base_state = StyleState(font_family="Test", font_size=24, auto_color=True)
+    analysis = _analysis(fill_rgb=(180, 180, 180), background_rgb=(200, 200, 200))
+    result = decide_style(analysis, base_state, AutoStyleConfig(target_contrast=4.5))
+    assert result.fill in ((0, 0, 0), (255, 255, 255))
+    assert result.stroke is not None
+    assert result.stroke_size >= 1


### PR DESCRIPTION
## Summary
- add a reusable `StyleState` schema, mask helpers, and WCAG utilities 
- implement colour analysis and decision logic plus an auto-style engine for sampling original text fill/stroke and contrast-safe fallbacks
- integrate the auto styling pipeline into batch and webtoon processors and cover the rules with unit tests

## Testing
- pytest tests/test_auto_style.py


------
https://chatgpt.com/codex/tasks/task_e_68e6794d98f48330822fd448e60d5a6d