### PR TITLE
Switch Chinese default OCR to EasyOCR

### DIFF
--- a/modules/ocr/factory.py
+++ b/modules/ocr/factory.py
@@ -7,6 +7,7 @@ from .microsoft_ocr import MicrosoftOCR
 from .google_ocr import GoogleOCR
 from .gpt_ocr import GPTOCR
 from .ppocr import PPOCRv5Engine
+from .easy_ocr import EasyOCREngine
 from .manga_ocr.onnx_engine import MangaOCREngineONNX
 from .pororo.onnx_engine import PororoOCREngineONNX  
 from .gemini_ocr import GeminiOCR
@@ -136,7 +137,7 @@ class OCRFactory:
         language_factories = {
             'Japanese': lambda s: cls._create_manga_ocr(s, backend),
             'Korean': lambda s: cls._create_pororo_ocr(s, backend),
-            'Chinese': lambda s: cls._create_ppocr(s, 'ch'),
+            'Chinese': lambda s: cls._create_easy_ocr(s),
             'Russian': lambda s: cls._create_ppocr(s, 'ru'),
             'French': lambda s: cls._create_ppocr(s, 'latin'),
             'English': lambda s: cls._create_ppocr(s, 'en'),
@@ -216,9 +217,19 @@ class OCRFactory:
         engine = PPOCRv5Engine()
         engine.initialize(lang=lang, device=device)
         return engine
-    
+
     @staticmethod
     def _create_gemini_ocr(settings, model) -> OCREngine:
         engine = GeminiOCR()
         engine.initialize(settings, model)
+        return engine
+
+    @staticmethod
+    def _create_easy_ocr(settings) -> OCREngine:
+        engine = EasyOCREngine()
+        engine.initialize(
+            languages=['chinese'],
+            use_gpu=settings.is_gpu_enabled(),
+            expansion_percentage=5
+        )
         return engine

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ onnxruntime>=1.22.1
 shapely>=2.1.1
 pyclipper>=1.3.0.post6
 pillow>=10.0.0
+easyocr>=1.7.1


### PR DESCRIPTION
## Summary
- replace the default Chinese OCR factory with an EasyOCR-backed engine
- wire EasyOCR initialization to the GPU toggle and add the dependency to requirements

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ed11f8335c83308eacf6ef198f4865