### PR TITLE
Fix EasyOCR Chinese language configuration

### DIFF
--- a/modules/ocr/factory.py
+++ b/modules/ocr/factory.py
@@ -227,8 +227,11 @@ class OCRFactory:
     @staticmethod
     def _create_easy_ocr(settings) -> OCREngine:
         engine = EasyOCREngine()
+        # EasyOCR expects ISO language codes rather than english names. The
+        # simplified Chinese model is the most commonly used for comics, so we
+        # default to it and include English for mixed text bubbles.
         engine.initialize(
-            languages=['chinese'],
+            languages=['ch_sim', 'en'],
             use_gpu=settings.is_gpu_enabled(),
             expansion_percentage=5
         )


### PR DESCRIPTION
## Summary
- update the EasyOCR factory to pass EasyOCR's supported Chinese language codes
- include English as a fallback for mixed-language Chinese text bubbles

## Testing
- pytest *(fails: missing system dependency libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68ed14373fac8330b5baf66ad4c0c241